### PR TITLE
Fix trailspace issues

### DIFF
--- a/lua/mini/trailspace.lua
+++ b/lua/mini/trailspace.lua
@@ -63,7 +63,7 @@ function MiniTrailspace.setup(config)
   )
 
   -- Create highlighting
-  vim.api.nvim_exec([[hi link MiniTrailspace Error]], false)
+  vim.api.nvim_exec([[hi default link MiniTrailspace Error]], false)
 end
 
 -- Module config
@@ -86,21 +86,27 @@ function MiniTrailspace.highlight(check_modifiable)
     return
   end
 
-  local win_id = vim.fn.win_getid()
-  local win_match = H.window_matches[win_id]
+  local win_id = vim.api.nvim_get_current_win()
+  if not vim.api.nvim_win_is_valid(win_id) then
+    return
+  end
 
   -- Don't add match id on top of existing one
-  if win_match == nil then
+  if H.window_matches[win_id] == nil then
     H.window_matches[win_id] = vim.fn.matchadd('MiniTrailspace', [[\s\+$]])
   end
 end
 
 --- Unhighlight trailing whitespace
 function MiniTrailspace.unhighlight()
-  local win_id = vim.fn.win_getid()
+  local win_id = vim.api.nvim_get_current_win()
+  if not vim.api.nvim_win_is_valid(win_id) then
+    return
+  end
+
   local win_match = H.window_matches[win_id]
   if win_match ~= nil then
-    vim.fn.matchdelete(win_match)
+    pcall(vim.fn.matchdelete, win_match)
     H.window_matches[win_id] = nil
   end
 end


### PR DESCRIPTION
Fixes two issues:

1. Highlight group can't be changed pending load order as it stands right now, use `default` when calling `hi` to handle these cases
2. Wrap the call to `vim.fn.matchdelete` with a `pcall` to avoid breaking things like _Telescope_ if the match doesn't exist

Also changes some calls that use `vim.fn` to use `vim.api` and check valid state, etc.

---

Curious, is there a reason to `defer_fn` on the `highlight` `:h autocmd` call? If we do that, the call to get the "current window" might not be accurate. Wanted to check before trying to change it here.