### PR TITLE
mini.jump (clever-f)

### DIFF
--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -1,0 +1,169 @@
+-- MIT License Copyright (c) 2021 Evgeni Chasnovski
+
+---@brief [[
+--- A module for smarter jumping, inspired by clever-f. By default it does nothing.
+---
+--- # Setup
+---
+--- This module needs a setup with `require('mini.jump').setup({})`
+--- (replace `{}` with your `config` table).
+---
+--- Default `config`:
+--- <pre>
+--- {
+---   -- Make f, F, t and T able to jump across lines and be repeated by pressing them again.
+---   map_ft = false,
+--- }
+--- </pre>
+---@brief ]]
+---@tag MiniJump mini.pairs
+
+-- Module and its helper
+local MiniJump = {}
+local H = {}
+
+--- Module setup
+---
+---@param config table: Module config table.
+---@usage `require('mini.completion').setup({})` (replace `{}` with your `config` table)
+function MiniJump.setup(config)
+  -- Export module
+  _G.MiniJump = MiniJump
+
+  -- Setup config
+  config = H.setup_config(config)
+
+  -- Apply config
+  H.apply_config(config)
+end
+
+-- Module config
+MiniJump.config = {
+  map_ft = false,
+}
+
+-- Module functionality
+MiniJump.target = nil
+MiniJump.ask_for_target = true
+
+function MiniJump.jump(target, backward, till)
+  local flags = 'W'
+  if backward then
+    flags = flags .. 'b'
+  end
+  if target == '\\' then
+    target = '\\\\'
+  end
+  local pattern
+  if target == "'" then
+    pattern = [["'"]]
+  else
+    pattern = [['\V]] .. target .. [[']]
+  end
+  local rhs = H.keys.cmd_start .. 'call search(' .. pattern .. ", '" .. flags .. "')" .. H.keys.cmd_end
+  if till then
+    if backward then
+      rhs = H.get_arrow_key('left') .. rhs .. H.get_arrow_key('right')
+    else
+      rhs = H.get_arrow_key('right') .. rhs .. H.get_arrow_key('left')
+    end
+  end
+  return rhs
+end
+
+function MiniJump.smart_jump(backward, till)
+  if MiniJump.ask_for_target then
+    MiniJump.target = H.get_char()
+  end
+  return MiniJump.jump(MiniJump.target, backward, till)
+    .. H.keys.cmd_start
+    .. [[lua MiniJump.ask_for_target = false]]
+    .. H.keys.cmd_end
+end
+
+-- Helpers
+---- Module default config
+H.default_config = MiniJump.config
+
+---- Settings
+function H.setup_config(config)
+  -- General idea: if some table elements are not present in user-supplied
+  -- `config`, take them from default config
+  vim.validate({ config = { config, 'table', true } })
+  config = vim.tbl_deep_extend('force', H.default_config, config or {})
+
+  vim.validate({
+    map_ft = { config.map_ft, 'boolean' },
+  })
+
+  return config
+end
+
+function H.apply_config(config)
+  MiniJump.config = config
+
+  mode = 'n'
+
+  if config.map_ft then
+    H.map(mode, 'f', [[v:lua.MiniJump.smart_jump(v:false, v:false)]])
+    H.map(mode, 'F', [[v:lua.MiniJump.smart_jump(v:true, v:false)]])
+    H.map(mode, 't', [[v:lua.MiniJump.smart_jump(v:false, v:true)]])
+    H.map(mode, 'T', [[v:lua.MiniJump.smart_jump(v:true, v:true)]])
+    vim.cmd([[autocmd CursorMoved * lua MiniJump.ask_for_target = true]])
+  end
+end
+
+function H.is_disabled()
+  return vim.g.minijump_disable == true or vim.b.minijump_disable == true
+end
+
+---- Various helpers
+function H.map(mode, key, command)
+  vim.api.nvim_set_keymap(mode, key, command, { expr = true, noremap = true })
+end
+
+function H.escape(s)
+  return vim.api.nvim_replace_termcodes(s, true, true, true)
+end
+
+-- stylua: ignore start
+H.keys = {
+  bs        = H.escape('<bs>'),
+  cr        = H.escape('<cr>'),
+  del       = H.escape('<del>'),
+  cmd_start = H.escape('<cmd>'),
+  cmd_end   = H.escape('<cr>'),
+  keep_undo = H.escape('<C-g>U'),
+  -- NOTE: use `get_arrow_key()` instead of `H.keys.left` or `H.keys.right`
+  left      = H.escape('<left>'),
+  right     = H.escape('<right>')
+}
+-- stylua: ignore end
+
+function H.get_arrow_key(key)
+  if vim.fn.mode() == 'i' then
+    -- Using left/right keys in insert mode breaks undo sequence and, more
+    -- importantly, dot-repeat. To avoid this, use 'i_CTRL-G_U' mapping.
+    return H.keys.keep_undo .. H.keys[key]
+  else
+    return H.keys[key]
+  end
+end
+
+function H.is_in_table(val, tbl)
+  if tbl == nil then
+    return false
+  end
+  for _, value in pairs(tbl) do
+    if val == value then
+      return true
+    end
+  end
+  return false
+end
+
+function H.get_char()
+  return vim.fn.nr2char(vim.fn.getchar())
+end
+
+return MiniJump

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -123,14 +123,16 @@ end
 function H.apply_config(config)
   MiniJump.config = config
 
-  mode = 'n'
+  modes = { 'n', 'o', 'x' }
 
-  if config.map_ft then
-    H.map_cmd(mode, 'f', [[lua MiniJump.smart_jump(1, false, false)]])
-    H.map_cmd(mode, 'F', [[lua MiniJump.smart_jump(1, true, false)]])
-    H.map_cmd(mode, 't', [[lua MiniJump.smart_jump(1, false, true)]])
-    H.map_cmd(mode, 'T', [[lua MiniJump.smart_jump(1, true, true)]])
-    vim.cmd([[autocmd CursorMoved * lua MiniJump.reset_target()]])
+  for _, mode in ipairs(modes) do
+    if config.map_ft then
+      H.map_cmd(mode, 'f', [[lua MiniJump.smart_jump(1, false, false)]])
+      H.map_cmd(mode, 'F', [[lua MiniJump.smart_jump(1, true, false)]])
+      H.map_cmd(mode, 't', [[lua MiniJump.smart_jump(1, false, true)]])
+      H.map_cmd(mode, 'T', [[lua MiniJump.smart_jump(1, true, true)]])
+      vim.cmd([[autocmd CursorMoved * lua MiniJump.reset_target()]])
+    end
   end
 end
 
@@ -140,8 +142,11 @@ end
 
 ---- Various helpers
 function H.map_cmd(mode, key, command)
-  -- For some reason, <cmd> doesn't work
-  vim.api.nvim_set_keymap(mode, key, ':' .. command .. H.keys.cmd_end, { noremap = true, silent = true })
+  local rhs = ('<cmd>%s<cr>'):format(command)
+  if mode == 'o' then
+    rhs = 'v' .. rhs
+  end
+  vim.api.nvim_set_keymap(mode, key, rhs, { noremap = true })
 end
 
 function H.escape(s)
@@ -153,8 +158,6 @@ H.keys = {
   bs        = H.escape('<bs>'),
   cr        = H.escape('<cr>'),
   del       = H.escape('<del>'),
-  cmd_start = H.escape('<cmd>'),
-  cmd_end   = H.escape('<cr>'),
   keep_undo = H.escape('<C-g>U'),
   -- NOTE: use `get_arrow_key()` instead of `H.keys.left` or `H.keys.right`
   left      = H.escape('<left>'),

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -128,8 +128,8 @@ function H.apply_config(config)
 
   modes = { 'n', 'o', 'x' }
 
-  for _, mode in ipairs(modes) do
-    if config.map_ft then
+  if config.map_ft then
+    for _, mode in ipairs(modes) do
       H.map_cmd(mode, 'f', [[lua MiniJump.smart_jump(1, false, false)]])
       H.map_cmd(mode, 'F', [[lua MiniJump.smart_jump(1, true, false)]])
       H.map_cmd(mode, 't', [[lua MiniJump.smart_jump(1, false, true)]])

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -82,12 +82,12 @@ function MiniJump.jump(target, backward, till)
   local hl_pattern = [[\V%s]]
   if till then
     if backward then
-      pattern = [[\V%s\.]]
-      hl_pattern = [[\V%s\ze\.]]
+      pattern = [[\V\(%s\)\@<=\.]]
+      hl_pattern = [[\V%s\.\@=]]
       flags = flags .. 'e'
     else
-      pattern = [[\V\.%s]]
-      hl_pattern = [[\V\.\zs%s]]
+      pattern = [[\V\.\(%s\)\@=]]
+      hl_pattern = [[\V\.\@<=%s]]
     end
   end
   pattern = pattern:format(vim.fn.escape(target, [[\]]))

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -76,7 +76,7 @@ end
 --- Smart jump
 ---
 --- If the last movement was a jump, perform another jump with the same target.
---- Otherwise, prompt for a target.
+--- Otherwise, prompt for a target. Respects v:count.
 ---
 --- @param num_chars number: The length of the target to prompt for.
 --- @param backward boolean: If true, jump backward.
@@ -88,6 +88,9 @@ function MiniJump.smart_jump(num_chars, backward, till)
   till = till or false
   local target = H.target or H.get_chars(num_chars)
   MiniJump.jump(target, backward, till)
+  for _ = 2, vim.v.count do
+    MiniJump.jump(target, backward, till)
+  end
   -- This has to be scheduled so it doesn't get overridden by CursorMoved from the jump.
   vim.schedule(function()
     H.target = target

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -126,9 +126,8 @@ end
 function H.apply_config(config)
   MiniJump.config = config
 
-  modes = { 'n', 'o', 'x' }
-
   if config.map_ft then
+    local modes = { 'n', 'o', 'x' }
     for _, mode in ipairs(modes) do
       H.map_cmd(mode, 'f', [[lua MiniJump.smart_jump(1, false, false)]])
       H.map_cmd(mode, 'F', [[lua MiniJump.smart_jump(1, true, false)]])

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -164,7 +164,7 @@ end
 
 function H.get_chars(num_chars)
   local chars = ''
-  for _ = 1,num_chars do
+  for _ = 1, num_chars do
     chars = chars .. vim.fn.nr2char(vim.fn.getchar())
   end
   return chars

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -162,7 +162,7 @@ function H.apply_config(config)
   H.map_cmd(modes, config.mappings.backward_1, [[lua MiniJump.smart_jump(1, true, false)]])
   H.map_cmd(modes, config.mappings.forward_1_till, [[lua MiniJump.smart_jump(1, false, true)]])
   H.map_cmd(modes, config.mappings.backward_1_till, [[lua MiniJump.smart_jump(1, true, true)]])
-  vim.cmd([[autocmd CursorMoved * lua MiniJump.reset_target()]])
+  vim.cmd([[autocmd BufLeave,CursorMoved,InsertEnter * lua MiniJump.reset_target()]])
 end
 
 function H.is_disabled()

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -101,8 +101,10 @@ function MiniJump.jump(target, backward, till)
   target = vim.fn.escape(target, [[\]])
   pattern, hl_pattern = pattern:format(target), hl_pattern:format(target)
 
-  vim.fn.search(pattern, flags)
   H.highlight(hl_pattern)
+  vim.fn.search(pattern, flags)
+  -- Open enough folds to show jump
+  vim.cmd([[normal! zv]])
 end
 
 --- Smart jump

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -45,17 +45,26 @@ MiniJump.config = {
 -- Module functionality
 H.target = nil
 
+--- Jump to target
+---
+--- Takes a string and jumps to the first occurence of it after the cursor.
+---
+--- @param target string: The string to jump to.
+--- @param backward boolean: If true, jump backward.
+--- @param till boolean: If true, jump just before/after the match instead of to the first character.
+---   Also ignore matches that don't have space before/after them. (This will probably be changed in the future.)
 function MiniJump.jump(target, backward, till)
   backward = backward or false
   till = till or false
   local flags = 'W'
   if backward then
-    flags = flags .. 'be'
+    flags = flags .. 'b'
   end
   local pattern = [[\V%s]]
   if till then
     if backward then
       pattern = [[\V%s\.]]
+      flags = flags .. 'e'
     else
       pattern = [[\V\.%s]]
     end
@@ -64,6 +73,15 @@ function MiniJump.jump(target, backward, till)
   vim.fn.search(pattern, flags)
 end
 
+--- Smart jump
+---
+--- If the last movement was a jump, perform another jump with the same target.
+--- Otherwise, prompt for a target.
+---
+--- @param num_chars number: The length of the target to prompt for.
+--- @param backward boolean: If true, jump backward.
+--- @param till boolean: If true, jump just before/after the match instead of to the first character.
+---   Also ignore matches that don't have space before/after them. (This will probably be changed in the future.)
 function MiniJump.smart_jump(num_chars, backward, till)
   num_chars = num_chars or 1
   backward = backward or false
@@ -76,7 +94,11 @@ function MiniJump.smart_jump(num_chars, backward, till)
   end)
 end
 
-function MiniJump.on_cursor_moved()
+--- Reset target
+---
+--- Forces the next smart jump to prompt for the target.
+--- Triggered automatically on CursorMoved, but can be also triggered manually.
+function MiniJump.reset_target()
   H.target = nil
 end
 
@@ -108,7 +130,7 @@ function H.apply_config(config)
     H.map_cmd(mode, 'F', [[lua MiniJump.smart_jump(1, true, false)]])
     H.map_cmd(mode, 't', [[lua MiniJump.smart_jump(1, false, true)]])
     H.map_cmd(mode, 'T', [[lua MiniJump.smart_jump(1, true, true)]])
-    vim.cmd([[autocmd CursorMoved * lua MiniJump.on_cursor_moved()]])
+    vim.cmd([[autocmd CursorMoved * lua MiniJump.reset_target()]])
   end
 end
 

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -119,7 +119,7 @@ end
 
 --- Reset target
 ---
---- Forces the next smart jump to prompt for the target.
+--- Removes highlights (if any) and forces the next smart jump to prompt for the target.
 --- Triggered automatically on CursorMoved, but can be also triggered manually.
 function MiniJump.reset_target()
   if not H.jumping then
@@ -182,40 +182,6 @@ end
 
 function H.escape(s)
   return vim.api.nvim_replace_termcodes(s, true, true, true)
-end
-
--- stylua: ignore start
-H.keys = {
-  bs        = H.escape('<bs>'),
-  cr        = H.escape('<cr>'),
-  del       = H.escape('<del>'),
-  keep_undo = H.escape('<C-g>U'),
-  -- NOTE: use `get_arrow_key()` instead of `H.keys.left` or `H.keys.right`
-  left      = H.escape('<left>'),
-  right     = H.escape('<right>')
-}
--- stylua: ignore end
-
-function H.get_arrow_key(key)
-  if vim.fn.mode() == 'i' then
-    -- Using left/right keys in insert mode breaks undo sequence and, more
-    -- importantly, dot-repeat. To avoid this, use 'i_CTRL-G_U' mapping.
-    return H.keys.keep_undo .. H.keys[key]
-  else
-    return H.keys[key]
-  end
-end
-
-function H.is_in_table(val, tbl)
-  if tbl == nil then
-    return false
-  end
-  for _, value in pairs(tbl) do
-    if val == value then
-      return true
-    end
-  end
-  return false
 end
 
 function H.get_chars(num_chars)

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -1,7 +1,10 @@
 -- MIT License Copyright (c) 2021 Evgeni Chasnovski, Adam Blažek
 
 ---@brief [[
---- A module for smarter jumping, inspired by clever-f. By default it does nothing.
+--- A module for smarter jumping, inspired by clever-f.
+--- By default it extends f, F, t, T to work on multiple lines,
+--- be repeatable by pressing f, F, t, T again,
+--- and highlight characters they're going to jump to.
 ---
 --- # Setup
 ---


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
- [x] Works in normal mode
- [x] Works in visual mode
- [x] Works in operator mode
- [x] Accepts `v:count`
- [x] Internal documentation
- [x] Highlighting

This is a module named `mini.jump`, implementing the basic functionality of [clever-f](https://github.com/rhysd/clever-f.vim) and a basis for the functionality of [vim-sneak](https://github.com/justinmk/vim-sneak).

~~Would this fit the spirit of this project? Should I also add two-char search like vim-sneak?~~

~~(Note: the implementation is currently a bit buggy, but the basic functionality works)~~