### PR TITLE
Fix typo in usage of mini.fuzzy

### DIFF
--- a/doc/mini.txt
+++ b/doc/mini.txt
@@ -917,7 +917,7 @@ MiniFuzzy.get_telescope_sorter({opts})      *MiniFuzzy.get_telescope_sorter()*
         {opts} (table)  Options (currently not used).
 
     Usage: ~
-        `require('telescope').setup({default = {generic_sorter =
+        `require('telescope').setup({defaults = {generic_sorter =
         require('mini.fuzzy').get_telescope_sorter}})`
 
 

--- a/lua/mini/fuzzy.lua
+++ b/lua/mini/fuzzy.lua
@@ -151,7 +151,7 @@ end
 --- |telescope.defaults.generic_sorter| inside `setup()` call.
 ---
 ---@param opts table: Options (currently not used).
----@usage `require('telescope').setup({default = {generic_sorter = require('mini.fuzzy').get_telescope_sorter}})`
+---@usage `require('telescope').setup({defaults = {generic_sorter = require('mini.fuzzy').get_telescope_sorter}})`
 function MiniFuzzy.get_telescope_sorter(opts)
   opts = opts or {}
 


### PR DESCRIPTION
- [ x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [ x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Fix key name of `telescope`: "default" -> "default **s** "