### PR TITLE
Feat(starter): Allow pass commands to sections.telescope

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 doc/tags
 deps
+.DS_Store

--- a/doc/mini.txt
+++ b/doc/mini.txt
@@ -3035,8 +3035,12 @@ Return~
 
 ------------------------------------------------------------------------------
                                               *MiniStarter.sections.telescope()*
-                       `MiniStarter.sections.telescope`()
+                       `MiniStarter.sections.telescope`({actions})
 Section with basic Telescope pickers relevant to start screen
+
+Parameters~
+{actions} `table` strings of telescope commands to be executed.
+  Defaults: {'file_browser', 'command_history', 'find_files', 'help_tags', 'live_grep', 'oldfiles'}
 
 Return~
 `(function)` Function which returns array of items.

--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -547,9 +547,16 @@ end
 --- Section with basic Telescope pickers relevant to start screen
 ---
 ---@return __section_fun
-function MiniStarter.sections.telescope()
-  return function()
-    return {
+function MiniStarter.sections.telescope(actions)
+
+  local action_tables = {}
+  if actions ~= nil then
+      for key, val in pairs(actions) do
+        table.insert(action_tables,
+            {action = 'Telescope ' .. val, name = val, section = 'Telescope'})
+      end
+  else
+    action_tables = {
       {action = 'Telescope file_browser',    name = 'Browser',         section = 'Telescope'},
       {action = 'Telescope command_history', name = 'Command history', section = 'Telescope'},
       {action = 'Telescope find_files',      name = 'Files',           section = 'Telescope'},
@@ -557,6 +564,9 @@ function MiniStarter.sections.telescope()
       {action = 'Telescope live_grep',       name = 'Live grep',       section = 'Telescope'},
       {action = 'Telescope oldfiles',        name = 'Old files',       section = 'Telescope'},
     }
+  end
+  return function()
+    return action_tables
   end
 end
 -- stylua: ignore end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

`starter.sections.telescope` is very convenient, but allowing customized commands would be best.