### PR TITLE
feat(mini.jump): Add idle timeout to stop jumping automatically

### DIFF
--- a/doc/mini.txt
+++ b/doc/mini.txt
@@ -1905,7 +1905,7 @@ by 'rhysd/clever-f.vim'.
 Features:
 - Extend f, F, t, T to work on multiple lines.
 - Repeat jump by pressing f, F, t, T again. It is reset when cursor moved
-  as a result of not jumping.
+  as a result of not jumping or timeout after idle time (duration customizable).
 - Highlight (after customizable delay) of all possible target characters.
 - Normal, Visual, and Operator-pending (with full dot-repeat) modes are
   supported.

--- a/doc/mini.txt
+++ b/doc/mini.txt
@@ -1960,13 +1960,18 @@ Default values:
       repeat_jump = ';',
     },
 
-    -- Delay (in ms) between jump and highlighting all possible jumps. Set to
-    -- a very big number (like 10^7) to virtually disable highlighting.
-    highlight_delay = 250,
+    delay = {
+      -- Delay (in ms) between jump and highlighting all possible jumps. Set to
+      -- a very big number (like 10^7) to virtually disable highlighting.
+      highlight = 250,
 
-    -- Timeout value (in ms) to stop jumping automatically after idle. Set to
-    -- a very big number (like 10^7) to virtually disable timeout.
-    idle_timeout = 1000000,
+      -- Timeout value (in ms) to stop jumping automatically after idle. Set to
+      -- a very big number (like 10^7) to virtually disable timeout.
+      idle_stop = 1000000,
+    },
+
+    -- DEPRECATION NOTICE:
+    -- `highlight_delay` is now deprecated, please use `delay.highlight` instead.
   }
 <
 

--- a/doc/mini.txt
+++ b/doc/mini.txt
@@ -1905,7 +1905,8 @@ by 'rhysd/clever-f.vim'.
 Features:
 - Extend f, F, t, T to work on multiple lines.
 - Repeat jump by pressing f, F, t, T again. It is reset when cursor moved
-  as a result of not jumping or timeout after idle time (duration customizable).
+  as a result of not jumping or timeout after idle time
+  (duration customizable).
 - Highlight (after customizable delay) of all possible target characters.
 - Normal, Visual, and Operator-pending (with full dot-repeat) modes are
   supported.
@@ -1962,6 +1963,10 @@ Default values:
     -- Delay (in ms) between jump and highlighting all possible jumps. Set to
     -- a very big number (like 10^7) to virtually disable highlighting.
     highlight_delay = 250,
+
+    -- Timeout value (in ms) to stop jumping automatically after idle. Set to
+    -- a very big number (like 10^7) to virtually disable timeout.
+    idle_timeout = 1000000,
   }
 <
 
@@ -1970,7 +1975,7 @@ Default values:
             `MiniJump.jump`({target}, {backward}, {till}, {n_times})
 Jump to target
 
-Takes a string and jumps to its first occurrence in desrired direction.
+Takes a string and jumps to its first occurrence in desired direction.
 
 Parameters~
 {target} `(string)` The string to jump to.

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -98,7 +98,7 @@ MiniJump.config = {
 -- Module functionality =======================================================
 --- Jump to target
 ---
---- Takes a string and jumps to its first occurrence in desrired direction.
+--- Takes a string and jumps to its first occurrence in desired direction.
 ---
 ---@param target string The string to jump to.
 ---@param backward __backward

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -7,7 +7,8 @@
 --- Features:
 --- - Extend f, F, t, T to work on multiple lines.
 --- - Repeat jump by pressing f, F, t, T again. It is reset when cursor moved
----   as a result of not jumping or timeout after idle time (duration customizable).
+---   as a result of not jumping or timeout after idle time
+---   (duration customizable).
 --- - Highlight (after customizable delay) of all possible target characters.
 --- - Normal, Visual, and Operator-pending (with full dot-repeat) modes are
 ---   supported.


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

This PR adds timeout after idle feature, inspired by lightspeed.nvim.
With this feature, you can reset highlights automatically, and start searching for another character easily.

The default value is set to `10^7`, so it won't break behavior compatibility.

