### PR TITLE
Add autochdir

### DIFF
--- a/doc/mini.txt
+++ b/doc/mini.txt
@@ -224,8 +224,8 @@ Setup with `require('mini.autochdir').setup({})` (replace `{}` with your
 you can use for scripting or manually (with `:lua MiniAutochdir.*`).
 
 # Example usage~
-- Modify default patterns to find a project root: >
-  require('mini.autochdir').setup({ patterns = { '.git' }})
+- Modify default root_pattern to find a project root: >
+  require('mini.autochdir').setup({ root_pattern = { '.git' }})
 - At the time changing a buffer, it also changes CWD.
 
 # Disabling~
@@ -234,6 +234,10 @@ To disable, set `g:miniautochdir_disable` (globally) or `b:miniautochdir_disable
 and customization intentions, writing exact rules for disabling module's
 functionality is left to user. See |mini.nvim-disabling-recipes| for common
 recipes.
+
+# Notice~
+https://github.com/mattn/vim-findroot is an OSS project licensed
+under the MIT License.
 
 
 ------------------------------------------------------------------------------
@@ -255,8 +259,8 @@ Module config
 Default values:
 >
   MiniAutochdir.config = {
-    -- Array of glob patterns to find a project root.
-    patterns = {
+    -- Array of glob root_pattern to find a project root.
+    root_pattern = {
       '.svn',
       '.hg',
       '.bzr',

--- a/doc/mini.txt
+++ b/doc/mini.txt
@@ -13,7 +13,7 @@ module can be considered as a separate sub-plugin.
 Table of contents:
   General overview.................................................|mini.nvim|
   Plugin colorscheme..............................................|minischeme|
-  better autochdir............................................|mini.autochdir|
+  Smart autochdir.............................................|mini.autochdir|
   Base16 colorscheme creation....................................|mini.base16|
   Remove buffers..............................................|mini.bufremove|
   Comment.......................................................|mini.comment|
@@ -366,7 +366,7 @@ Default values:
       'vue.config.js',
       '.zk',
       'zls.json',
-    }
+    },
   }
 <
 

--- a/doc/mini.txt
+++ b/doc/mini.txt
@@ -13,6 +13,7 @@ module can be considered as a separate sub-plugin.
 Table of contents:
   General overview.................................................|mini.nvim|
   Plugin colorscheme..............................................|minischeme|
+  better autochdir............................................|mini.autochdir|
   Base16 colorscheme creation....................................|mini.base16|
   Remove buffers..............................................|mini.bufremove|
   Comment.......................................................|mini.comment|
@@ -198,6 +199,180 @@ where `palette` is:
     `require('mini.base16').mini_palette('#e2e5ca', '#002a83', 75)`
 
 Activate it as a regular |colorscheme|.
+
+
+==============================================================================
+------------------------------------------------------------------------------
+                                                                *mini.autochdir*
+                                                                 *MiniAutochdir*
+Automatically change directory to a project root.
+Main inspiration is a "mattn/vim-findroot" and "airblade/vim-rooter" plugin.
+
+Features:
+  Automatically change directory to a project root defined in
+  |MiniAutochdir.config|. The patterns are written in the glob pattern.
+
+General overview of how to find a project root:
+- Check whether the designated file or the directory
+  exists in current directory.
+- If not, move to the parent directory to find a project root.
+
+# Setup~
+This module doesn't need setup, but it can be done to improve usability.
+Setup with `require('mini.autochdir').setup({})` (replace `{}` with your
+`config` table). It will create global Lua table `MiniAutochdir` which
+you can use for scripting or manually (with `:lua MiniAutochdir.*`).
+
+# Example usage~
+- Modify default patterns to find a project root: >
+  require('mini.autochdir').setup({ patterns = { '.git' }})
+- At the time changing a buffer, it also changes CWD.
+
+# Disabling~
+To disable, set `g:miniautochdir_disable` (globally) or `b:miniautochdir_disable`
+(for a buffer) to `v:true`. Considering high number of different scenarios
+and customization intentions, writing exact rules for disabling module's
+functionality is left to user. See |mini.nvim-disabling-recipes| for common
+recipes.
+
+
+------------------------------------------------------------------------------
+                                                         *MiniAutochdir.setup()*
+                        `MiniAutochdir.setup`({config})
+Module setup
+
+Parameters~
+{config} `(table)` Module config table. See |MiniAutochdir.config|.
+
+Usage~
+`require('mini.autochdir').setup({})` (replace `{}` with your `config` table)
+
+------------------------------------------------------------------------------
+                                                          *MiniAutochdir.config*
+                             `MiniAutochdir.config`
+Module config
+
+Default values:
+>
+  MiniAutochdir.config = {
+    -- Array of glob patterns to find a project root.
+    patterns = {
+      '.svn',
+      '.hg',
+      '.bzr',
+      '*.adc',
+      'angular.json',
+      'bower.json',
+      'build',
+      'BUILD.bazel',
+      'build.boot',
+      'build.gradle',
+      'build.sbt',
+      'build.sc',
+      '*.cabal',
+      'cabal.config',
+      'cabal.project',
+      'Cargo.toml',
+      'compile_commands.json',
+      'composer.json',
+      '.csproj',
+      'deno.json',
+      'deno.jsonc',
+      'deps.edn',
+      'Dockerfile',
+      'dub.json',
+      'dub.sdl',
+      'dune-project',
+      'dune-workspace',
+      'elm.json',
+      'ember-cli-build.js',
+      'erlang.mk',
+      'esy.json',
+      'flake.nix',
+      '.flowconfig',
+      '.fortls',
+      'Gemfile',
+      '.git',
+      '.golangci.yaml',
+      'go.mod',
+      'go.work',
+      '*.gpr',
+      '.graphql.config.*',
+      'graphql.config.*',
+      '.graphqlrc*',
+      '.hhconfig',
+      'hie-bios',
+      'hiera.yaml',
+      'hie.yaml',
+      '*.hxml',
+      'jsconfig.json',
+      'jsonnetfile.json',
+      'lakefile.lean',
+      'leanpkg.toml',
+      'lean-toolchain',
+      '.luacheckrc',
+      '.luarc.json',
+      'Makefile',
+      'manifests',
+      '.marksman.toml',
+      'meson.build',
+      'mix.exs',
+      'node_modules',
+      'ols.json',
+      '*.opam',
+      'package.json',
+      'Package.swift',
+      'package.yaml',
+      'pom.xml',
+      'postcss.config.js',
+      'postcss.config.ts',
+      'project.clj',
+      'project.godot',
+      'psalm.xml',
+      'psalm.xml.dist',
+      'psc-package.json',
+      'pubspec.yaml',
+      '.puppet-lint.rc',
+      'pyproject.toml',
+      'rebar.config',
+      'requirements.txt',
+      'robotidy.toml',
+      'rust-project.json',
+      'selene.toml',
+      'settings.gradle',
+      'sfdx-project.json',
+      'shadow-cljs.edn',
+      'shard.yml',
+      'shell.nix',
+      '.sln',
+      'spago.dhall',
+      'stack.yaml',
+      'Steepfile',
+      '.stylelintrc',
+      '.stylua.toml',
+      '.svlangserver',
+      'tailwind.config.js',
+      'tailwind.config.ts',
+      '.terraform',
+      '.tflint.hcl',
+      'tlconfig.lua',
+      '*.toml',
+      'tsconfig.json',
+      'v.mod',
+      'vue.config.js',
+      '.zk',
+      'zls.json',
+    }
+  }
+<
+
+------------------------------------------------------------------------------
+                                                      *MiniAutochdir.findroot()*
+                           `MiniAutochdir.findroot`()
+Find a project root from the directory of current buffer.
+
+Return~
+`(...)` this function returns nothing.
 
 
 ==============================================================================

--- a/lua/mini/autochdir.lua
+++ b/lua/mini/autochdir.lua
@@ -31,6 +31,10 @@
 --- functionality is left to user. See |mini.nvim-disabling-recipes| for common
 --- recipes.
 ---
+--- # Notice~
+--- https://github.com/mattn/vim-findroot is an OSS project licensed
+--- under the MIT License.
+---
 ---@tag mini.autochdir
 ---@tag MiniAutochdir
 ---@toc_entry better autochdir

--- a/lua/mini/autochdir.lua
+++ b/lua/mini/autochdir.lua
@@ -216,7 +216,7 @@ function H.goup(path, root_pattern)
   while true do
     for _, pattern in ipairs(root_pattern) do
       local path_pattern = path .. '/' .. pattern
-      if pattern:find('*') ~= nil and not vim.fn.glob(path_pattern, 1) == '' then
+      if pattern:find('*') ~= nil and vim.fn.glob(path_pattern, 1) ~= '' then
         return path
       elseif vim.fn.isdirectory(path_pattern) or vim.fn.filereadable(path_pattern) then
         return path

--- a/lua/mini/autochdir.lua
+++ b/lua/mini/autochdir.lua
@@ -1,0 +1,251 @@
+-- MIT License Copyright (c) 2021 Evgeni Chasnovski
+
+-- Documentation ==============================================================
+--- Automatically change directory to a project root.
+--- Main inspiration is a "mattn/vim-findroot" and "airblade/vim-rooter" plugin.
+---
+--- Features:
+---   Automatically change directory to a project root defined in
+---   |MiniAutochdir.config|. The patterns are written in the glob pattern.
+---
+--- General overview of how to find a project root:
+--- - Check whether the designated file or the directory
+---   exists in current directory.
+--- - If not, move to the parent directory to find a project root.
+---
+--- # Setup~
+--- This module doesn't need setup, but it can be done to improve usability.
+--- Setup with `require('mini.autochdir').setup({})` (replace `{}` with your
+--- `config` table). It will create global Lua table `MiniAutochdir` which
+--- you can use for scripting or manually (with `:lua MiniAutochdir.*`).
+---
+--- # Example usage~
+--- - Modify default patterns to find a project root: >
+---   require('mini.autochdir').setup({ patterns = { '.git' }})
+--- - At the time changing a buffer, it also changes CWD.
+---
+--- # Disabling~
+--- To disable, set `g:miniautochdir_disable` (globally) or `b:miniautochdir_disable`
+--- (for a buffer) to `v:true`. Considering high number of different scenarios
+--- and customization intentions, writing exact rules for disabling module's
+--- functionality is left to user. See |mini.nvim-disabling-recipes| for common
+--- recipes.
+---
+---@tag mini.autochdir
+---@tag MiniAutochdir
+---@toc_entry better autochdir
+-- Module definition ==========================================================
+
+local MiniAutochdir = {}
+local H = {}
+
+--- Module setup
+---
+---@param config table Module config table. See |MiniAutochdir.config|.
+---
+---@usage `require('mini.autochdir').setup({})` (replace `{}` with your `config` table)
+function MiniAutochdir.setup(config)
+  -- Export module
+  _G.MiniAutochdir = MiniAutochdir
+
+  -- Setup config
+  config = H.setup_config(config)
+
+  -- Apply config
+  H.apply_config(config)
+end
+
+--- Module config
+---
+--- Default values:
+---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
+MiniAutochdir.config = {
+  -- Array of glob patterns to find a project root.
+  patterns = {
+    '.svn',
+    '.hg',
+    '.bzr',
+    '*.adc',
+    'angular.json',
+    'bower.json',
+    'build',
+    'BUILD.bazel',
+    'build.boot',
+    'build.gradle',
+    'build.sbt',
+    'build.sc',
+    '*.cabal',
+    'cabal.config',
+    'cabal.project',
+    'Cargo.toml',
+    'compile_commands.json',
+    'composer.json',
+    '.csproj',
+    'deno.json',
+    'deno.jsonc',
+    'deps.edn',
+    'Dockerfile',
+    'dub.json',
+    'dub.sdl',
+    'dune-project',
+    'dune-workspace',
+    'elm.json',
+    'ember-cli-build.js',
+    'erlang.mk',
+    'esy.json',
+    'flake.nix',
+    '.flowconfig',
+    '.fortls',
+    'Gemfile',
+    '.git',
+    '.golangci.yaml',
+    'go.mod',
+    'go.work',
+    '*.gpr',
+    '.graphql.config.*',
+    'graphql.config.*',
+    '.graphqlrc*',
+    '.hhconfig',
+    'hie-bios',
+    'hiera.yaml',
+    'hie.yaml',
+    '*.hxml',
+    'jsconfig.json',
+    'jsonnetfile.json',
+    'lakefile.lean',
+    'leanpkg.toml',
+    'lean-toolchain',
+    '.luacheckrc',
+    '.luarc.json',
+    'Makefile',
+    'manifests',
+    '.marksman.toml',
+    'meson.build',
+    'mix.exs',
+    'node_modules',
+    'ols.json',
+    '*.opam',
+    'package.json',
+    'Package.swift',
+    'package.yaml',
+    'pom.xml',
+    'postcss.config.js',
+    'postcss.config.ts',
+    'project.clj',
+    'project.godot',
+    'psalm.xml',
+    'psalm.xml.dist',
+    'psc-package.json',
+    'pubspec.yaml',
+    '.puppet-lint.rc',
+    'pyproject.toml',
+    'rebar.config',
+    'requirements.txt',
+    'robotidy.toml',
+    'rust-project.json',
+    'selene.toml',
+    'settings.gradle',
+    'sfdx-project.json',
+    'shadow-cljs.edn',
+    'shard.yml',
+    'shell.nix',
+    '.sln',
+    'spago.dhall',
+    'stack.yaml',
+    'Steepfile',
+    '.stylelintrc',
+    '.stylua.toml',
+    '.svlangserver',
+    'tailwind.config.js',
+    'tailwind.config.ts',
+    '.terraform',
+    '.tflint.hcl',
+    'tlconfig.lua',
+    '*.toml',
+    'tsconfig.json',
+    'v.mod',
+    'vue.config.js',
+    '.zk',
+    'zls.json',
+  }
+}
+--minidoc_afterlines_end
+
+-- Module functionality =======================================================
+--- Find a project root from the directory of current buffer.
+---
+---@return ... this function returns nothing.
+function MiniAutochdir.findroot()
+  if H.is_disabled() then
+    return
+  end
+
+  local bufname = vim.fn.expand('%:p')
+  if vim.o.buftype ~= '' or bufname == '' or bufname:find('://') then
+    return
+  end
+  local patterns = MiniAutochdir.config.patterns
+  local dir = vim.fn.fnamemodify(bufname, ':p:h:gs!\\!/!:gs!//!/!')
+  dir = vim.fn.escape(dir, ' ')
+  dir = H.goup(dir, patterns)
+  if not dir then
+    return
+  end
+  vim.fn.chdir(dir)
+  print('cwd: ' .. dir)
+end
+
+vim.cmd[[
+augroup MiniAutochdir
+  autocmd!
+  autocmd BufEnter * :lua require('mini.autochdir').findroot()
+augroup END
+]]
+
+-- Helper functionality =======================================================
+-- Directory walker -----------------------------------------------------------
+--
+-- This returns the path which matches the pattern. If not, it returns nil.
+function H.goup(path, patterns)
+  -- General idea: go up directory from the given path.
+  -- It returns the path which matches the patterns.
+  while true do
+    for _, pattern in ipairs(patterns) do
+      local path_pattern = path .. '/' .. pattern
+      if pattern:find('*') ~= nil and not vim.fn.glob(path_pattern, 1) == '' then
+        return path
+      elseif vim.fn.isdirectory(path_pattern) or vim.fn.filereadable(path_pattern) then
+        return path
+      end
+    end
+    local parent_dir = vim.fn.fnamemodify(path, ':h')
+    if parent_dir == path or (vim.fn.has('win32') and parent_dir:match('^//[^/]+$')) then
+      break
+    end
+    path = parent_dir
+  end
+  return nil
+end
+
+-- Module default config
+H.default_config = MiniAutochdir.config
+
+-- Settings -------------------------------------------------------------------
+function H.setup_config(config)
+  vim.validate({ config = { config, 'table', true } })
+  config = vim.tbl_deep_extend('force', H.default_config, config or {})
+
+  vim.validate({ patterns = { config.patterns, 'table' } })
+
+  return config
+end
+
+function H.apply_config(config)
+  MiniAutochdir.config = config
+end
+
+function H.is_disabled()
+  return vim.g.minijump2d_disable or vim.b.minijump2d_disable
+end
+
+return MiniAutochdir

--- a/lua/mini/autochdir.lua
+++ b/lua/mini/autochdir.lua
@@ -20,8 +20,8 @@
 --- you can use for scripting or manually (with `:lua MiniAutochdir.*`).
 ---
 --- # Example usage~
---- - Modify default patterns to find a project root: >
----   require('mini.autochdir').setup({ patterns = { '.git' }})
+--- - Modify default root_pattern to find a project root: >
+---   require('mini.autochdir').setup({ root_pattern = { '.git' }})
 --- - At the time changing a buffer, it also changes CWD.
 ---
 --- # Disabling~
@@ -64,8 +64,8 @@ end
 --- Default values:
 ---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
 MiniAutochdir.config = {
-  -- Array of glob patterns to find a project root.
-  patterns = {
+  -- Array of glob root_pattern to find a project root.
+  root_pattern = {
     '.svn',
     '.hg',
     '.bzr',
@@ -188,10 +188,10 @@ function MiniAutochdir.findroot()
   if vim.o.buftype ~= '' or bufname == '' or bufname:find('://') then
     return
   end
-  local patterns = MiniAutochdir.config.patterns
+  local root_pattern = MiniAutochdir.config.root_pattern
   local dir = vim.fn.fnamemodify(bufname, ':p:h:gs!\\!/!:gs!//!/!')
   dir = vim.fn.escape(dir, ' ')
-  dir = H.goup(dir, patterns)
+  dir = H.goup(dir, root_pattern)
   if not dir then
     return
   end
@@ -210,11 +210,11 @@ augroup END
 -- Directory walker -----------------------------------------------------------
 --
 -- This returns the path which matches the pattern. If not, it returns nil.
-function H.goup(path, patterns)
+function H.goup(path, root_pattern)
   -- General idea: go up directory from the given path.
-  -- It returns the path which matches the patterns.
+  -- It returns the path which matches the root_pattern.
   while true do
-    for _, pattern in ipairs(patterns) do
+    for _, pattern in ipairs(root_pattern) do
       local path_pattern = path .. '/' .. pattern
       if pattern:find('*') ~= nil and not vim.fn.glob(path_pattern, 1) == '' then
         return path
@@ -239,7 +239,7 @@ function H.setup_config(config)
   vim.validate({ config = { config, 'table', true } })
   config = vim.tbl_deep_extend('force', H.default_config, config or {})
 
-  vim.validate({ patterns = { config.patterns, 'table' } })
+  vim.validate({ root_pattern = { config.root_pattern, 'table' } })
 
   return config
 end

--- a/lua/mini/autochdir.lua
+++ b/lua/mini/autochdir.lua
@@ -37,7 +37,7 @@
 ---
 ---@tag mini.autochdir
 ---@tag MiniAutochdir
----@toc_entry better autochdir
+---@toc_entry Smart autochdir
 -- Module definition ==========================================================
 
 local MiniAutochdir = {}
@@ -171,7 +171,7 @@ MiniAutochdir.config = {
     'vue.config.js',
     '.zk',
     'zls.json',
-  }
+  },
 }
 --minidoc_afterlines_end
 
@@ -199,12 +199,12 @@ function MiniAutochdir.findroot()
   print('cwd: ' .. dir)
 end
 
-vim.cmd[[
+vim.cmd([[
 augroup MiniAutochdir
   autocmd!
   autocmd BufEnter * :lua require('mini.autochdir').findroot()
 augroup END
-]]
+]])
 
 -- Helper functionality =======================================================
 -- Directory walker -----------------------------------------------------------

--- a/tests/autochdir_spec.lua
+++ b/tests/autochdir_spec.lua
@@ -33,13 +33,13 @@ describe('MiniAutochdir.setup()', function()
     end
 
     -- Check default values
-    assert_config('patterns', 105)
+    assert_config('root_pattern', 105)
   end)
 
   it('respects `config` argument', function()
     unload_module()
-    load_module({ patterns = {} })
-    eq(child.lua_get('MiniAutochdir.config.patterns'), {})
+    load_module({ root_pattern = {} })
+    eq(child.lua_get('MiniAutochdir.config.root_pattern'), {})
   end)
 
   it('validates `config` argument', function()
@@ -52,7 +52,7 @@ describe('MiniAutochdir.setup()', function()
     end
 
     assert_config_error('a', 'config', 'table')
-    assert_config_error({ patterns = 'a' }, 'patterns', 'table')
+    assert_config_error({ root_pattern = 'a' }, 'root_pattern', 'table')
   end)
 end)
 

--- a/tests/autochdir_spec.lua
+++ b/tests/autochdir_spec.lua
@@ -1,0 +1,68 @@
+local helpers = require('tests.helpers')
+
+local child = helpers.new_child_neovim()
+local eq = assert.are.same
+
+-- Helpers with child processes
+--stylua: ignore start
+local load_module = function(config) child.mini_load('autochdir', config) end
+local unload_module = function() child.mini_unload('autochdir') end
+--stylua: ignore end
+
+-- Unit tests =================================================================
+describe('MiniAutochdir.setup()', function()
+  before_each(function()
+    child.setup()
+    load_module()
+  end)
+
+  it('creates side effects', function()
+    -- Global variable
+    assert.True(child.lua_get('_G.MiniAutochdir ~= nil'))
+
+    -- Autocommand group
+    eq(child.fn.exists('#MiniAutochdir'), 1)
+  end)
+
+  it('creates `config` field', function()
+    eq(child.lua_get('type(_G.MiniAutochdir.config)'), 'table')
+
+    -- Check default values
+    local assert_config = function(field, value)
+      eq(#(child.lua_get('MiniAutochdir.config.' .. field)), value)
+    end
+
+    -- Check default values
+    assert_config('patterns', 105)
+  end)
+
+  it('respects `config` argument', function()
+    unload_module()
+    load_module({ patterns = {} })
+    eq(child.lua_get('MiniAutochdir.config.patterns'), {})
+  end)
+
+  it('validates `config` argument', function()
+    unload_module()
+
+    local assert_config_error = function(config, name, target_type)
+      assert.error_matches(function()
+        load_module(config)
+      end, vim.pesc(name) .. '.*' .. vim.pesc(target_type))
+    end
+
+    assert_config_error('a', 'config', 'table')
+    assert_config_error({ patterns = 'a' }, 'patterns', 'table')
+  end)
+end)
+
+describe('MiniAutochdir.findroot()', function()
+  child.setup()
+  load_module()
+
+  it('works', function()
+    eq(child.fn.getcwd(), vim.fn.getcwd())
+  end)
+end)
+
+child.stop()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Automatically change directory to a project root.
Main inspiration is a "mattn/vim-findroot" and "airblade/vim-rooter" plugin.

Features:
- Automatically change directory to a project root defined in
 `MiniAutochdir.config`. The patterns are written in the glob pattern.

General overview of how to find a project root:
- Check whether the designated file or the directory exists in current directory.
- If not, move to the parent directory to find a project root.