### PR TITLE
Fix mini.jump highlighting & command output

### DIFF
--- a/doc/mini.txt
+++ b/doc/mini.txt
@@ -1974,6 +1974,11 @@ Features:
 - Normal, Visual, and Operator-pending (with full dot-repeat) modes are
   supported.
 
+This module follows vim's 'ignorecase' and 'smartcase' options. When
+'ignorecase' is set, f, F, t, T will match case-insensitively. When
+'smartcase' is also set, f, F, t, T will only match lowercase
+characters case-insensitively.
+
 # Setup~
 
 This module needs a setup with `require('mini.jump').setup({})`

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -168,17 +168,21 @@ function MiniJump.jump(target, backward, till, n_times)
 
   -- Construct search and highlight patterns
   local flags = MiniJump.state.backward and 'Wb' or 'W'
-  local pattern, hl_pattern = [[\V%s]], [[\V%s]]
+  local hl_case = ''
+  if vim.o.ignorecase and (not vim.o.smartcase or escaped_target == escaped_target:lower()) then
+    hl_case = [[\c]]
+  end
+  local pattern, hl_pattern = [[\V%s]], [[\V%s%s]]
   if MiniJump.state.till then
     if MiniJump.state.backward then
-      pattern, hl_pattern = [[\V\(%s\)\@<=\.]], [[\V%s\.\@=]]
+      pattern, hl_pattern = [[\V\(%s\)\@<=\.]], [[\V%s%s\.\@=]]
       flags = ('%se'):format(flags)
     else
-      pattern, hl_pattern = [[\V\.\(%s\)\@=]], [[\V\.\@<=%s]]
+      pattern, hl_pattern = [[\V\.\(%s\)\@=]], [[\V%s\.\@<=%s]]
     end
   end
 
-  pattern, hl_pattern = pattern:format(escaped_target), hl_pattern:format(escaped_target)
+  pattern, hl_pattern = pattern:format(escaped_target), hl_pattern:format(hl_case, escaped_target)
 
   -- Delay highlighting after stopping previous one
   H.timers.highlight:stop()

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -13,6 +13,11 @@
 --- - Normal, Visual, and Operator-pending (with full dot-repeat) modes are
 ---   supported.
 ---
+--- This module follows vim's 'ignorecase' and 'smartcase' options. When
+--- 'ignorecase' is set, f, F, t, T will match case-insensitively. When
+--- 'smartcase' is also set, f, F, t, T will only match lowercase
+--- characters case-insensitively.
+---
 --- # Setup~
 ---
 --- This module needs a setup with `require('mini.jump').setup({})`

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -275,7 +275,7 @@ function MiniJump.expr_jump(backward, till)
   end
   H.update_state(target, backward, till, vim.v.count1)
 
-  return vim.api.nvim_replace_termcodes('v:<C-u>lua MiniJump.jump()<CR>', true, true, true)
+  return vim.api.nvim_replace_termcodes('v<Cmd>lua MiniJump.jump()<CR>', true, true, true)
 end
 
 --- Stop jumping

--- a/tests/jump_spec.lua
+++ b/tests/jump_spec.lua
@@ -662,6 +662,54 @@ describe('Jumping with f/t/F/T', function()
     validate_disable('g')
     validate_disable('b')
   end)
+
+  it('respects vim.o.ignorecase', function()
+    child.cmd('set ignorecase')
+    set_lines({ ' 1e2E3E4e_ ' })
+
+    set_cursor(1, 0)
+    type_keys('2f', 'E')
+    eq(get_cursor(), { 1, 4 })
+
+    set_cursor(1, 0)
+    type_keys('2t', 'E')
+    eq(get_cursor(), { 1, 3 })
+
+    set_cursor(1, 10)
+    type_keys('2F', 'E')
+    eq(get_cursor(), { 1, 6 })
+
+    set_cursor(1, 10)
+    type_keys('2T', 'E')
+    eq(get_cursor(), { 1, 7 })
+
+    child.cmd('set noignorecase')
+  end)
+
+  it('respects vim.o.smartcase', function()
+    child.cmd('set ignorecase')
+    child.cmd('set smartcase')
+    set_lines({ ' 1e2E3E4e_ ' })
+
+    set_cursor(1, 0)
+    type_keys('2f', 'E')
+    eq(get_cursor(), { 1, 6 })
+
+    set_cursor(1, 0)
+    type_keys('2t', 'E')
+    eq(get_cursor(), { 1, 5 })
+
+    set_cursor(1, 10)
+    type_keys('2F', 'E')
+    eq(get_cursor(), { 1, 4 })
+
+    set_cursor(1, 10)
+    type_keys('2T', 'E')
+    eq(get_cursor(), { 1, 5 })
+
+    child.cmd('set nosmartcase')
+    child.cmd('set noignorecase')
+  end)
 end)
 
 describe('Repeat jump with ;', function()
@@ -864,6 +912,34 @@ describe('Delayed highlighting', function()
     type_keys('ct', 'f')
     sleep(test_times.highlight)
     eq(highlights_target('f', false, true), false)
+  end)
+
+  it('respects ignorecase', function()
+    child.cmd('set ignorecase')
+    set_lines({ '1e2E' })
+
+    set_cursor(1, 0)
+    type_keys('f', 'e')
+
+    sleep(test_times.highlight)
+    eq(highlights_target([[\ce]], false, false), true)
+
+    child.cmd('set noignorecase')
+  end)
+
+  it('respects smartcase', function()
+    child.cmd('set ignorecase')
+    child.cmd('set smartcase')
+    set_lines({ '1e2E3e4E' })
+
+    set_cursor(1, 0)
+    type_keys('f', 'E')
+
+    sleep(test_times.highlight)
+    eq(highlights_target([[E]], false, false), true)
+
+    child.cmd('set nosmartcase')
+    child.cmd('set noignorecase')
   end)
 end)
 


### PR DESCRIPTION
I started using mini.jump recently, and noticed a couple issues.

1. Highlights don't include capital letters, but you still jump to them by default. After a bit of testing, I confirmed this is because I use the `ignorecase` and `smartcase` vim options.
2. Highlights appear when used with an operator, despite the fact that you can't actually perform a repeat.
3. In operator pending mode, we print a spurious `lua MiniJump.jump()` to the statusline.

I made a few commits to polish these up.

Regarding case sensitivity, I personally _like_ that this plugin follows `ignorecase`, and so all I did was fix the disparity between jumping and highlighting. However, it does seem like respecting `ignorecase` in this plugin may not have been intentional. If you'd rather fix this, I would be happy to instead work on adding explicit `ignorecase`/`smartcase` options instead.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
