### PR TITLE
(mini.starter) Reset query after activation when evaluate_single is true

### DIFF
--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -1241,6 +1241,7 @@ H.make_query = function(buf_id, query)
   -- Possibly evaluate single active item
   if H.get_config().evaluate_single and n_active == 1 then
     MiniStarter.eval_current_item(buf_id)
+    MiniStarter.set_query(nil, buf_id)
     return
   end
 


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [X] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

When `evaluate_single == true`, it makes sense to me to clear the query after an item is activated.

If I'm reading it correctly, the only benefit to keeping the query string is to add more onto it, but `evaluate_single` has already ensured that the query string is at a leaf---adding more to the query string will never match any more or less than it does already.

Resetting the query string after activating a single item brings mini.nvim more in line with startify and alpha. Start screen items are logically discrete, and after activating one the need to backspace out the current query feels like a "gotcha."