### PR TITLE
[MiniJump2d] Replace <CR>-mapping based on the FileType event

### DIFF
--- a/lua/mini/jump2d.lua
+++ b/lua/mini/jump2d.lua
@@ -134,7 +134,7 @@ MiniJump2d.setup = function(config)
     vim.api.nvim_exec(
       [[augroup MiniJump2d
           au!
-          autocmd BufWinEnter quickfix nnoremap <buffer> <CR> <CR>
+          autocmd FileType qf nnoremap <buffer> <CR> <CR>
           autocmd CmdwinEnter * nnoremap <buffer> <CR> <CR>
         augroup END]],
       false


### PR DESCRIPTION
I automatically open the quickfix list when using commands like `:grep`/`:vimgrep` using an implementation that hooks into the `QuickFixCmdPost` event, similar to [this implementation](https://vim.fandom.com/wiki/Automatically_open_the_quickfix_window_on_:make).

```vim
autocmd QuickFixCmdPost [^l]* nested cwindow
autocmd QuickFixCmdPost    l* nested lwindow
```
I see that MiniJump2d [attempts to replace](https://github.com/echasnovski/mini.nvim/blob/main/lua/mini/jump2d.lua#L137) the <CR> mapping in a quickfix list. However, sometimes, the mapping is not replaced and hitting `<CR>` in the quickfix list activates MiniJump2d instead of navigating to the file. This may be due to a race condition on when the events are fired. Closing and re-opening the quickfix list "fixes" this problem, because the `BufWinEnter` event kicks in again.

Based on the [quickfix documentation](https://neovim.io/doc/user/quickfix.html)...
> When the quickfix window has been filled, two autocommand events are
triggered.  First the ['filetype'](https://neovim.io/doc/user/options.html#'filetype') option is set to "qf", which triggers the
FileType event (also see [qf.vim](https://neovim.io/doc/user/filetype.html#qf.vim)).  Then the BufReadPost event is triggered,
using "quickfix" for the buffer name.

I'm replacing the `BufWinEnter` implementation with the `FileType` event.

----

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
