### PR TITLE
(mini.indentscope) Add option for a prefix symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## mini.indentscope
 
-- FEATURE: Add 'prefix' option to specify a prefix character in place of virtual text hard-coded space. Empty string value provides the ability to use this module with 'listchar' options ('lead', 'tab' and 'leadmultispace') without overwriting user-selected characters.
+- FEATURE: Add 'prefix' option to specify a prefix character in place of virtual text hard-coded space. Empty string value provides the ability to use this module with 'listchars' option ('lead', 'tab' and 'leadmultispace') without overwriting user-selected characters.
 
 # Version 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## mini.indentscope
 
-- FEATURE: Add 'prefix' option to specify a prefix character in place of virtual text hard-coded space. It provides the ability to use this module with 'listchars=lead:<char>' option without overwriting user-selected character with spaces.
+- FEATURE: Add 'prefix' option to specify a prefix character in place of virtual text hard-coded space. Empty string value provides the ability to use this module with 'listchar' options ('lead', 'tab' and 'leadmultispace') without overwriting user-selected characters.
 
 # Version 0.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 - Start dual distribution. Every module is now distributed both as part of 'mini.nvim' library and as standalone plugin (in separate git repository).
 
+## mini.indentscope
+
+- FEATURE: Add 'prefix' option to specify a prefix character in place of virtual text hard-coded space. It provides the ability to use this module with 'listchars=lead:<char>' option without overwriting user-selected character with spaces.
+
 # Version 0.6.0
 
 - Stop official support of Neovim 0.5.

--- a/doc/mini-indentscope.txt
+++ b/doc/mini-indentscope.txt
@@ -152,7 +152,9 @@ Default values:
     -- Which character to use for drawing scope indicator
     symbol = '╎',
 
-    -- Which character to use for drawing a scope indicator prefix
+    -- Which character to use for drawing a scope indicator prefix.
+    -- In case of an empty string, prefix will not be drawn, allowing to keep
+    -- the visibility of listchars.
     prefix = ' ',
   }
 <

--- a/doc/mini-indentscope.txt
+++ b/doc/mini-indentscope.txt
@@ -151,6 +151,9 @@ Default values:
 
     -- Which character to use for drawing scope indicator
     symbol = '╎',
+
+    -- Which character to use for drawing a scope indicator prefix
+    prefix = ' ',
   }
 <
 # Options ~

--- a/lua/mini/indentscope.lua
+++ b/lua/mini/indentscope.lua
@@ -231,7 +231,9 @@ MiniIndentscope.config = {
   -- Which character to use for drawing scope indicator
   symbol = '╎',
 
-  -- Which character to use for drawing a scope indicator prefix
+  -- Which character to use for drawing a scope indicator prefix.
+  -- In case of an empty string, prefix will not be drawn, allowing to keep
+  -- the visibility of listchars.
   prefix = ' ',
 }
 --minidoc_afterlines_end

--- a/lua/mini/indentscope.lua
+++ b/lua/mini/indentscope.lua
@@ -794,9 +794,11 @@ H.indicator_compute = function(scope)
   -- Usage separate highlight groups for prefix and symbol allows cursor to be
   -- "natural" when on the left of indicator line (like on empty lines)
   local virt_text = { { H.get_config().symbol, 'MiniIndentscopeSymbol' } }
-  local prefix = string.rep(H.get_config().prefix, col)
   -- Currently Neovim doesn't work when text for extmark is empty string
-  if prefix:len() > 0 then table.insert(virt_text, 1, { prefix, 'MiniIndentscopePrefix' }) end
+  if col > 0 and H.get_config().prefix ~= '' then
+    local prefix = string.rep(H.get_config().prefix, col)
+    table.insert(virt_text, 1, { prefix, 'MiniIndentscopePrefix' })
+  end
 
   local top = scope.body.top
   local bottom = scope.body.bottom
@@ -804,7 +806,7 @@ H.indicator_compute = function(scope)
   return {
     buf_id = vim.api.nvim_get_current_buf(),
     virt_text = virt_text,
-    virt_text_win_col = prefix:len() > 0 and 0 or col,
+    virt_text_win_col = H.get_config().prefix == '' and col or 0,
     top = top,
     bottom = bottom,
   }

--- a/lua/mini/indentscope.lua
+++ b/lua/mini/indentscope.lua
@@ -230,6 +230,9 @@ MiniIndentscope.config = {
 
   -- Which character to use for drawing scope indicator
   symbol = '╎',
+
+  -- Which character to use for drawing a scope indicator prefix
+  prefix = ' ',
 }
 --minidoc_afterlines_end
 
@@ -658,6 +661,7 @@ H.setup_config = function(config)
     mappings = { config.mappings, 'table' },
     options = { config.options, 'table' },
     symbol = { config.symbol, 'string' },
+    prefix = { config.prefix, 'string' },
   })
 
   vim.validate({
@@ -790,7 +794,7 @@ H.indicator_compute = function(scope)
   -- Usage separate highlight groups for prefix and symbol allows cursor to be
   -- "natural" when on the left of indicator line (like on empty lines)
   local virt_text = { { H.get_config().symbol, 'MiniIndentscopeSymbol' } }
-  local prefix = string.rep(' ', indent - leftcol)
+  local prefix = string.rep(H.get_config().prefix, indent - leftcol)
   -- Currently Neovim doesn't work when text for extmark is empty string
   if prefix:len() > 0 then table.insert(virt_text, 1, { prefix, 'MiniIndentscopePrefix' }) end
 


### PR DESCRIPTION
This small change adds an ability to use a user-defined symbol for a prefix instead of only a hard-coded space character. The idea is to allow the usage of this plugin with a leading space 'listchar' option enabled.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

## Context

Hi! Thanks a lot for a very cool and minimalistic plugin to provide a nice indent visualization without introducing a performance penalty!

I've been using a `listchars` vim option for a while to visualize leading tabs and whitespaces, so when I've stared using `mini.indentscope` plugin, I've noticed that it overwrites existing `NonText` marks with a blank space:

<img width="593" alt="before" src="https://user-images.githubusercontent.com/5783792/201978241-e583531e-975d-4e54-ab46-6a92ed5aaea4.png">

I think the option to provide a user-defined prefix character instead of hard-coded `' '` could be useful to `listchars` users without introducing a performance penalty. With this patch it's possible to keep the visible whitespaces while getting a highlighted scope under cursor (using the following config):
```lua
vim.o.listchars = 'lead:┆'
require('mini.indentscope').setup { prefix = '┆' }
```

<img width="593" alt="after" src="https://user-images.githubusercontent.com/5783792/201978801-22ac64a9-ef4e-4470-a184-cae47cd54b0c.png">

It can also provide users with ability to customize scope visualization with existing `MiniIndentscopePrefix` highlight.

In any case, thanks again for a great and very useful Neovim plugin!