### PR TITLE
[mini.starter] `stopinsert` instead of `normal! <Esc>` to force normal mode

### DIFF
--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -1280,7 +1280,7 @@ end
 H.apply_buffer_options = function(buf_id)
   -- NOTE: assumed that it is executing with `buf_id` being current buffer
   -- Force Normal mode
-  vim.cmd('stopinsert')
+  vim.cmd('normal! <C-\\><C-n>')
 
   -- Set buffer name
   H.buffer_number = H.buffer_number + 1

--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -1280,7 +1280,7 @@ end
 H.apply_buffer_options = function(buf_id)
   -- NOTE: assumed that it is executing with `buf_id` being current buffer
   -- Force Normal mode
-  vim.cmd('normal! <ESC>')
+  vim.cmd('stopinsert')
 
   -- Set buffer name
   H.buffer_number = H.buffer_number + 1

--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -1280,7 +1280,7 @@ end
 H.apply_buffer_options = function(buf_id)
   -- NOTE: assumed that it is executing with `buf_id` being current buffer
   -- Force Normal mode
-  vim.cmd('normal! <C-\\><C-n>')
+  vim.cmd('stopinsert')
 
   -- Set buffer name
   H.buffer_number = H.buffer_number + 1

--- a/tests/test_starter.lua
+++ b/tests/test_starter.lua
@@ -275,12 +275,61 @@ T['open()']['respects `vim.b.ministarter_config`'] = function()
   child.expect_screenshot()
 end
 
-T['open()']['does not fire `InsertEnter`'] = function()
+T['open()']['does not trigger `InsertEnter`'] = function()
   child.b.ministarter_config = { header = 'Hello', footer = 'World', content_hooks = {} }
   child.g.insert_enter_fired = 0
   child.cmd('autocmd InsertEnter * let g:insert_enter_fired = 1')
   child.lua('MiniStarter.open()')
   eq(child.g.insert_enter_fired, 0)
+end
+
+T['open()']['forces normal mode from insert mode'] = function()
+  child.b.ministarter_config = { header = 'Hello', footer = 'World', content_hooks = {} }
+  child.type_keys('i')
+  eq(child.fn.mode(), 'i')
+  child.lua('MiniStarter.open()')
+  eq(child.fn.mode(), 'n')
+end
+
+T['open()']['forces normal mode from visual mode'] = function()
+  child.b.ministarter_config = { header = 'Hello', footer = 'World', content_hooks = {} }
+  child.type_keys('v')
+  eq(child.fn.mode(), 'v')
+  child.lua('MiniStarter.open()')
+  eq(child.fn.mode(), 'n')
+end
+
+T['open()']['forces normal mode from terminal mode'] = function()
+  child.b.ministarter_config = { header = 'Hello', footer = 'World', content_hooks = {} }
+  child.cmd('term')
+  child.type_keys('i')
+  eq(child.fn.mode(), 't')
+  child.lua('MiniStarter.open()')
+  eq(child.fn.mode(), 'n')
+end
+
+T['open()']['forces normal mode from replace mode'] = function()
+  child.b.ministarter_config = { header = 'Hello', footer = 'World', content_hooks = {} }
+  child.type_keys('R')
+  eq(child.fn.mode(), 'R')
+  child.lua('MiniStarter.open()')
+  eq(child.fn.mode(), 'n')
+end
+
+T['open()']['forces normal mode from virtual replace mode'] = function()
+  child.b.ministarter_config = { header = 'Hello', footer = 'World', content_hooks = {} }
+  child.type_keys('gR')
+  eq(child.fn.mode(), 'R')
+  child.lua('MiniStarter.open()')
+  eq(child.fn.mode(), 'n')
+end
+
+T['open()']['forces normal mode from select mode'] = function()
+  child.b.ministarter_config = { header = 'Hello', footer = 'World', content_hooks = {} }
+  child.type_keys('gh')
+  eq(child.fn.mode(), 's')
+  child.lua('MiniStarter.open()')
+  eq(child.fn.mode(), 'n')
 end
 
 T['refresh()'] = new_set()

--- a/tests/test_starter.lua
+++ b/tests/test_starter.lua
@@ -275,6 +275,14 @@ T['open()']['respects `vim.b.ministarter_config`'] = function()
   child.expect_screenshot()
 end
 
+T['open()']['does not fire `InsertEnter`'] = function()
+  child.b.ministarter_config = { header = 'Hello', footer = 'World', content_hooks = {} }
+  child.g.insert_enter_fired = 0
+  child.cmd('autocmd InsertEnter * let g:insert_enter_fired = 1')
+  child.lua('MiniStarter.open()')
+  eq(child.g.insert_enter_fired, 0)
+end
+
 T['refresh()'] = new_set()
 
 T['refresh()']['does `header` normalization'] = function()


### PR DESCRIPTION
For whatever reason, `normal! <ESC>` triggers the `InsertEnter` event, which interferes with some autocommands that I would like not to tigger on the start page. An alternative way to force normal mode is the `stopinsert` command:

```help
:stopi[nsert]		Stop Insert mode or |Terminal-mode| as soon as
			possible.  Works like typing <Esc> in Insert mode.
			Can be used in an autocommand, example:  
				:au BufEnter scratch stopinsert

```


- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
