### PR TITLE
fix(mini.map): winblend description

### DIFF
--- a/doc/mini-map.txt
+++ b/doc/mini-map.txt
@@ -340,8 +340,8 @@ map line. Default: `true`.
 integration count column. Default: 10.
 
 `window.winblend` - value of 'winblend' for map window. Value 0 makes it
-completely non-transparent, 100 - completely transparent (content is still
-visible, but with slightly different highlights).
+completely transparent, 100 makes it completely opaque (content still will
+be visible on transparent mode, but with slightly different highlights).
 
 # Pure scrollbar config ~
 


### PR DESCRIPTION
## DOC: Fix the reverse description of winblend on mini.map

### 0 makes it transparent:
![0](https://user-images.githubusercontent.com/45848083/215269761-b05931d3-7c8a-4091-ad33-aadd255a181a.png)

### 100 makes it opaque:
![100](https://user-images.githubusercontent.com/45848083/215269777-6c1260b2-1abd-4d52-b0e5-704973703bc1.png)

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
