### PR TITLE
Annotate config setup tables as optional

### DIFF
--- a/lua/mini/base16.lua
+++ b/lua/mini/base16.lua
@@ -143,7 +143,7 @@ local H = {}
 --- - Table with similar structure to `palette` but having terminal colors
 ---   (integers from 0 to 255) instead of hex strings.
 ---
----@param config table Module config table. See |MiniBase16.config|.
+---@param config table|nil Module config table. See |MiniBase16.config|.
 ---
 ---@usage `require('mini.base16').setup({})` (replace `{}` with your `config`
 ---   table; `config.palette` should be a table with colors)

--- a/lua/mini/bufremove.lua
+++ b/lua/mini/bufremove.lua
@@ -41,7 +41,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniBufremove.config|.
+---@param config table|nil Module config table. See |MiniBufremove.config|.
 ---
 ---@usage `require('mini.bufremove').setup({})` (replace `{}` with your `config` table)
 MiniBufremove.setup = function(config)

--- a/lua/mini/comment.lua
+++ b/lua/mini/comment.lua
@@ -44,7 +44,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniComment.config|.
+---@param config table|nil Module config table. See |MiniComment.config|.
 ---
 ---@usage `require('mini.comment').setup({})` (replace `{}` with your `config` table)
 MiniComment.setup = function(config)

--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -181,7 +181,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniCompletion.config|.
+---@param config table|nil Module config table. See |MiniCompletion.config|.
 ---
 ---@usage `require('mini.completion').setup({})` (replace `{}` with your `config` table)
 MiniCompletion.setup = function(config)

--- a/lua/mini/cursorword.lua
+++ b/lua/mini/cursorword.lua
@@ -72,7 +72,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniCursorword.config|.
+---@param config table|nil Module config table. See |MiniCursorword.config|.
 ---
 ---@usage `require('mini.cursorword').setup({})` (replace `{}` with your `config` table)
 MiniCursorword.setup = function(config)

--- a/lua/mini/doc.lua
+++ b/lua/mini/doc.lua
@@ -145,7 +145,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniDoc.config|.
+---@param config table|nil Module config table. See |MiniDoc.config|.
 ---
 ---@usage `require('mini.doc').setup({})` (replace `{}` with your `config` table)
 MiniDoc.setup = function(config)

--- a/lua/mini/fuzzy.lua
+++ b/lua/mini/fuzzy.lua
@@ -60,7 +60,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniFuzzy.config|.
+---@param config table|nil Module config table. See |MiniFuzzy.config|.
 ---
 ---@usage `require('mini.fuzzy').setup({})` (replace `{}` with your `config` table)
 MiniFuzzy.setup = function(config)

--- a/lua/mini/indentscope.lua
+++ b/lua/mini/indentscope.lua
@@ -96,7 +96,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniIndentscope.config|.
+---@param config table|nil Module config table. See |MiniIndentscope.config|.
 ---
 ---@usage `require('mini.indentscope').setup({})` (replace `{}` with your `config` table)
 MiniIndentscope.setup = function(config)

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -61,7 +61,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniJump.config|.
+---@param config table|nil Module config table. See |MiniJump.config|.
 ---
 ---@usage `require('mini.jump').setup({})` (replace `{}` with your `config` table)
 MiniJump.setup = function(config)

--- a/lua/mini/jump2d.lua
+++ b/lua/mini/jump2d.lua
@@ -116,7 +116,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniJump2d.config|.
+---@param config table|nil Module config table. See |MiniJump2d.config|.
 ---
 ---@usage `require('mini.jump2d').setup({})` (replace `{}` with your `config` table)
 MiniJump2d.setup = function(config)

--- a/lua/mini/misc.lua
+++ b/lua/mini/misc.lua
@@ -39,7 +39,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniMisc.config|.
+---@param config table|nil Module config table. See |MiniMisc.config|.
 ---
 ---@usage `require('mini.misc').setup({})` (replace `{}` with your `config` table)
 MiniMisc.setup = function(config)

--- a/lua/mini/pairs.lua
+++ b/lua/mini/pairs.lua
@@ -88,7 +88,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniPairs.config|.
+---@param config table|nil Module config table. See |MiniPairs.config|.
 ---
 ---@usage `require('mini.completion').setup({})` (replace `{}` with your `config` table)
 MiniPairs.setup = function(config)

--- a/lua/mini/sessions.lua
+++ b/lua/mini/sessions.lua
@@ -54,7 +54,7 @@ local H = { path_sep = package.config:sub(1, 1) }
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniSessions.config|.
+---@param config table|nil Module config table. See |MiniSessions.config|.
 ---
 ---@usage `require('mini.sessions').setup({})` (replace `{}` with your `config` table)
 MiniSessions.setup = function(config)

--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -188,7 +188,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniStarter.config|.
+---@param config table|nil Module config table. See |MiniStarter.config|.
 ---
 ---@usage `require('mini.starter').setup({})` (replace `{}` with your `config` table)
 MiniStarter.setup = function(config)

--- a/lua/mini/statusline.lua
+++ b/lua/mini/statusline.lua
@@ -114,7 +114,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniStatusline.config|.
+---@param config table|nil Module config table. See |MiniStatusline.config|.
 ---
 ---@usage `require('mini.statusline').setup({})` (replace `{}` with your `config` table)
 MiniStatusline.setup = function(config)

--- a/lua/mini/surround.lua
+++ b/lua/mini/surround.lua
@@ -413,7 +413,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniSurround.config|.
+---@param config table|nil Module config table. See |MiniSurround.config|.
 ---
 ---@usage `require('mini.surround').setup({})` (replace `{}` with your `config` table)
 MiniSurround.setup = function(config)

--- a/lua/mini/tabline.lua
+++ b/lua/mini/tabline.lua
@@ -69,7 +69,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniTabline.config|.
+---@param config table|nil Module config table. See |MiniTabline.config|.
 ---
 ---@usage `require('mini.tabline').setup({})` (replace `{}` with your `config` table)
 MiniTabline.setup = function(config)

--- a/lua/mini/trailspace.lua
+++ b/lua/mini/trailspace.lua
@@ -46,7 +46,7 @@ local H = {}
 
 --- Module setup
 ---
----@param config table Module config table. See |MiniTrailspace.config|.
+---@param config table|nil Module config table. See |MiniTrailspace.config|.
 ---
 ---@usage `require('mini.trailspace').setup({})` (replace `{}` with your `config` table)
 MiniTrailspace.setup = function(config)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Currently, not all mini modules have their config setup tables annotated as optional even though they have noted:
> -- No need to copy this inside `setup()`. Will be used automatically.

E.g.: https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-trailspace.md#installation

For those modules it results in a type error.

<img src="https://user-images.githubusercontent.com/34311583/216035444-3ded90f7-64bc-4765-9e22-60a341805994.png">

Of course a user can just pass an empty `{}` to silent the error.
But I feel like the right solution would be to annotate them correctly as optional.

Usually marking a param as optional is done by adding a question mark, `<type>?`. But I followed the convention in the modules that have marked it's config tables as optional by addling `|nil`. If this should changed, please let me know. I think it could be nicely done in one wash with this PR. 
