### PR TITLE
[mini.ai]: add 'verbose' option to suppress messages

### DIFF
--- a/lua/mini/ai.lua
+++ b/lua/mini/ai.lua
@@ -501,6 +501,9 @@ MiniAi.config = {
   -- neighborhood). One of 'cover', 'cover_or_next', 'cover_or_prev',
   -- 'cover_or_nearest', 'next', 'prev', 'nearest'.
   search_method = 'cover_or_next',
+
+  -- Print message if a textobject can't be found
+  verbose = true,
 }
 --minidoc_afterlines_end
 
@@ -538,7 +541,7 @@ MiniAi.find_textobject = function(ai_type, id, opts)
   -- Find region
   local res = H.find_textobject_region(tobj_spec, ai_type, opts)
 
-  if res == nil then
+  if H.get_config().verbose and res == nil then
     local msg = string.format(
       [[No textobject %s found covering region%s within %d line%s and `search_method = '%s'`.]],
       vim.inspect(ai_type .. id),

--- a/readmes/mini-ai.md
+++ b/readmes/mini-ai.md
@@ -183,6 +183,9 @@ Here are code snippets for some common installation methods (use only one):
   -- neighborhood). One of 'cover', 'cover_or_next', 'cover_or_prev',
   -- 'cover_or_nearest', 'next', 'previous', 'nearest'.
   search_method = 'cover_or_next',
+
+  -- Print message if a textobject can't be found
+  verbose = true,
 }
 ```
 


### PR DESCRIPTION
Adds the option `verbose` which (when set to `false`) disables messages like this:

```
(mini.ai) No textobject "ib" found covering region within 50 lines and `search_method = 'next'`.
```

Neovim doesn't print any message if you try to access built-in text-objects like `i"`, `a)`, that don't exist. Therefore I think it's reasonable to have an option to disable mini.ai's messages.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
