### PR TITLE
fix: typo s/move/bracketed/ in "this link" link

### DIFF
--- a/readmes/mini-bracketed.md
+++ b/readmes/mini-bracketed.md
@@ -10,7 +10,7 @@ See more details in [Features](#features) and [help file](../doc/mini-bracketed.
 
 ---
 
-⦿ This is a part of [mini.nvim](https://github.com/echasnovski/mini.nvim) library. Please use [this link](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-move.md) if you want to mention this module.
+⦿ This is a part of [mini.nvim](https://github.com/echasnovski/mini.nvim) library. Please use [this link](https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-bracketed.md) if you want to mention this module.
 
 ⦿ All contributions (issues, pull requests, discussions, etc.) are done inside of 'mini.nvim'.
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Noticed a small typo. Looking forward to trying out the new module! 🙂 