### PR TITLE
fix(doc): Reflects the directory hierarchy.

### DIFF
--- a/lua/mini/doc.lua
+++ b/lua/mini/doc.lua
@@ -809,9 +809,10 @@ H.default_input = function()
       if vim.fn.fnamemodify(a, ':h') == vim.fn.fnamemodify(b, ':h') then
         if vim.fn.fnamemodify(a, ':t') == 'init.lua' then return true end
         if vim.fn.fnamemodify(b, ':t') == 'init.lua' then return false end
+        return a < b
       end
 
-      return a < b
+      return vim.fn.fnamemodify(a, ":h") < vim.fn.fnamemodify(b, ":h")
     end)
     table.insert(res, files)
   end


### PR DESCRIPTION
Fixed a behavior that "foo/bar/init.lua" takes precedence over "foo/init.lua" when "foo/bar/init.lua" and "foo/init.lua" exist. 

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
