### PR TITLE
(mini.basics) Keep default nohl mapping in Neovim

### DIFF
--- a/lua/mini/basics.lua
+++ b/lua/mini/basics.lua
@@ -671,7 +671,7 @@ H.keymap_set = function(modes, lhs, rhs, opts)
     local map_info = H.get_map_info(mode, lhs)
     local is_default = map_info == nil
       -- Some mappings are set by default in Neovim
-      or (mode == 'n' and lhs == '<C-L>' and map_info.rhs:find('nohl') ~= nil)
+      or (mode == 'n' and lhs == '<C-l>' and map_info.rhs:find('nohl') ~= nil)
       or (mode == 'x' and lhs == '*' and map_info.rhs == [[y/\V<C-R>"<CR>]])
       or (mode == 'x' and lhs == '#' and map_info.rhs == [[y?\V<C-R>"<CR>]])
     if not is_default then return end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Neovim's default nohl mapping is `C-l` instead of `C-L`.