### PR TITLE
(mini.basics) Map 'jk' as <ESC>

### DIFF
--- a/lua/mini/basics.lua
+++ b/lua/mini/basics.lua
@@ -564,8 +564,15 @@ H.apply_mappings = function(config)
     -- Copy/paste with system clipboard
     map({ 'n', 'x' }, 'gy', '"+y', { desc = 'Copy to system clipboard' })
     map(  'n',        'gp', '"+p', { desc = 'Paste from system clipboard' })
-    -- - Paste in Visual with `P` to not copy selected text (`:h v_P`)
+
+    -- Paste in Visual with `P` to not copy selected text (`:h v_P`)
     map(  'x',        'gp', '"+P', { desc = 'Paste from system clipboard' })
+
+    -- Map ESC
+    map('i', 'jj', "ESC")
+    map('i', 'jk', "ESC")
+    map('i', 'kk', "ESC")
+    map('i', 'kj', "ESC")
 
     -- Reselect latest changed, put, or yanked text
     map('n', 'gV', '"`[" . strpart(getregtype(), 0, 1) . "`]"', { expr = true, desc = 'Visually select changed text' })


### PR DESCRIPTION
- [ ] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [ ] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)


There is a line of document says:"    -- Basic mappings (better 'jk', save with Ctrl+S, ...)"
But I didn't find the mapping of "better jk" so I added it.
I'm not a native English speaker so I'm sorry if my words are confusing.
