### PR TITLE
(mini.misc) Don't run filetype autocmd if the buffer is not a normal buffer

### DIFF
--- a/lua/mini/misc.lua
+++ b/lua/mini/misc.lua
@@ -302,6 +302,9 @@ MiniMisc.setup_restore_cursor = function(opts)
   vim.api.nvim_create_autocmd('BufReadPre', {
     group = augroup,
     callback = function(data)
+      -- Stop if not a normal buffer
+      if vim.bo.buftype ~= '' then return end
+
       vim.api.nvim_create_autocmd('FileType', {
         buffer = data.buf,
         once = true,
@@ -312,9 +315,6 @@ MiniMisc.setup_restore_cursor = function(opts)
 end
 
 H.restore_cursor = function(opts)
-  -- Stop if not a normal buffer
-  if vim.bo.buftype ~= '' then return end
-
   -- Stop if filetype is ignored
   if vim.tbl_contains(opts.ignore_filetype, vim.bo.filetype) then return end
 


### PR DESCRIPTION
We can already leave earlier ...

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
