### PR TITLE
(mini.starter) Fix refresh on resize

### DIFF
--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -1283,7 +1283,7 @@ H.make_buffer_autocmd = function(buf_id)
     vim.api.nvim_create_autocmd(event, { group = augroup, buffer = buf_id, callback = callback, desc = desc })
   end
 
-  au('VimResized', MiniStarter.refresh, 'Refresh')
+  au('VimResized', function() MiniStarter.refresh(buf_id) end, 'Refresh')
   au('CursorMoved', function() H.position_cursor_on_current_item(buf_id) end, 'Position cursor')
 
   local cache_showtabline = vim.o.showtabline


### PR DESCRIPTION
This is a simple fix for `mini.starter` not refreshing when Neovim is resized, due to `MiniStarter.refresh()` unintentionally being passed an invalid argument.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
