### PR TITLE
(mini.indentscope) Enable only on normal buffers

### DIFF
--- a/lua/mini/indentscope.lua
+++ b/lua/mini/indentscope.lua
@@ -678,7 +678,7 @@ end
 
 -- Autocommands ---------------------------------------------------------------
 H.auto_draw = function(opts)
-  if H.is_disabled() then
+  if vim.bo.buftype ~= '' or H.is_disabled() then
     H.undraw_scope()
     return
   end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Hey, Indentscope is enabled automatically unless `miniindentscope_disable` is explicitly set, which makes it a bit annoying on buffers you will never edit. I could put this under a flag if you think that's better, however IMO the feature only makes sense on normal buffers. What do you think?