### PR TITLE
(mini.files) Fix typos on comment

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -1896,7 +1896,7 @@ end
 H.window_get_max_height = function()
   local has_tabline = vim.o.showtabline == 2 or (vim.o.showtabline == 1 and #vim.api.nvim_list_tabpages() > 1)
   local has_statusline = vim.o.laststatus > 0
-  -- Remove 2 from maximum hight to accout for top and bottom borders
+  -- Remove 2 from maximum height to account for top and bottom borders
   return vim.o.lines - vim.o.cmdheight - (has_tabline and 1 or 0) - (has_statusline and 1 or 0) - 2
 end
 


### PR DESCRIPTION
I found these typos while browsing the source code ^^'

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
