### PR TITLE
(mini.bufremove) create modifiable buffer rather than a scratch buffer

### DIFF
--- a/lua/mini/bufremove.lua
+++ b/lua/mini/bufremove.lua
@@ -29,7 +29,7 @@
 ---    decided by the algorithm:
 ---    - If alternate buffer (see |CTRL-^|) is listed (see |buflisted()|), use it.
 ---    - If previous listed buffer (see |bprevious|) is different, use it.
----    - Otherwise create a scratch one with `nvim_create_buf(true, true)` and use
+---    - Otherwise create a new one with `nvim_create_buf(true, false)` and use
 ---      it.
 ---
 --- # Disabling~
@@ -158,7 +158,7 @@ MiniBufremove.unshow_in_window = function(win_id)
     if cur_buf ~= vim.api.nvim_win_get_buf(win_id) then return end
 
     -- Create new listed scratch buffer
-    local new_buf = vim.api.nvim_create_buf(true, true)
+    local new_buf = vim.api.nvim_create_buf(true, false)
     vim.api.nvim_win_set_buf(win_id, new_buf)
   end)
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

When closing the last buffer with `bufremove` it gives you a scratch buffer rather than just a normal buffer. This means if you modify it and run `:confirm q` it won't warn before closing. This can be pretty detrimental especially for people who are used to core vim behavior. By just creating a normal buffer without the `nofile` buffer type we can re-align `mini.bufremove` with the core vim behavior that people may be accustom to. This also remains un-opinionated because it doesn't set any file types or buffer types.

If you don't want this change, it could be a good idea to have a configuration option that allows users to align themselves with the core vim behavior if they are used to it.

This also would resolve #372 confusion