### PR TITLE
(mini.basics) Fix typo in help.

### DIFF
--- a/doc/mini-basics.txt
+++ b/doc/mini-basics.txt
@@ -312,9 +312,9 @@ It will only add a mapping if it wasn't manually created before.
 
 Here is a list of created mappings (`<M-x>` means `Alt`/`Meta` plus `x`):
 - `<M-h>` - move cursor left.  Modes: Insert, Terminal, Command.
-- `<M-h>` - move cursor down.  Modes: Insert, Terminal.
-- `<M-h>` - move cursor up.    Modes: Insert, Terminal.
-- `<M-h>` - move cursor right. Modes: Insert, Terminal, Command.
+- `<M-j>` - move cursor down.  Modes: Insert, Terminal.
+- `<M-k>` - move cursor up.    Modes: Insert, Terminal.
+- `<M-l>` - move cursor right. Modes: Insert, Terminal, Command.
 
                                                 *MiniBasics.config.autocommands*
 # Autocommands ~

--- a/lua/mini/basics.lua
+++ b/lua/mini/basics.lua
@@ -283,9 +283,9 @@ end
 ---
 --- Here is a list of created mappings (`<M-x>` means `Alt`/`Meta` plus `x`):
 --- - `<M-h>` - move cursor left.  Modes: Insert, Terminal, Command.
---- - `<M-h>` - move cursor down.  Modes: Insert, Terminal.
---- - `<M-h>` - move cursor up.    Modes: Insert, Terminal.
---- - `<M-h>` - move cursor right. Modes: Insert, Terminal, Command.
+--- - `<M-j>` - move cursor down.  Modes: Insert, Terminal.
+--- - `<M-k>` - move cursor up.    Modes: Insert, Terminal.
+--- - `<M-l>` - move cursor right. Modes: Insert, Terminal, Command.
 ---
 ---                                                 *MiniBasics.config.autocommands*
 --- # Autocommands ~


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [X] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Fixes typo in `mini.basics` help docs for `<M-hjkl>` moves.