### PR TITLE
(mini.basics) Use a more specific 'TermOpen' autocomand pattern

### DIFF
--- a/lua/mini/basics.lua
+++ b/lua/mini/basics.lua
@@ -721,7 +721,7 @@ H.apply_autocommands = function(config)
 
   if config.autocommands.basic then
     au('TextYankPost', '*', function() vim.highlight.on_yank() end, 'Highlight yanked text')
-    au('TermOpen', '*', function() vim.cmd('startinsert') end, 'Start builtin terminal in Insert mode')
+    au('TermOpen', 'term://*', function() vim.cmd('startinsert') end, 'Start builtin terminal in Insert mode')
   end
 
   if config.autocommands.relnum_in_visual_mode then


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

***

The pattern that the “Start builtin terminal in Insert mode” autocommand is using is not specific enough, which seems to cause [Neogit](https://github.com/NeogitOrg/neogit) to open in insert mode which shouldn’t be possible, causing an error that stops Neogit being used until the `esc` key is hit:

`E21: Cannot make changes, ‘modifiable’ is off`

Minimal setup example (using lazy as a plugin manager):

```lua
require("lazy").setup({
  {
    "echasnovski/mini.nvim",
    init = function()
      require("mini.basics").setup({})
    end
  },
  {
    "NeogitOrg/neogit",
    dependencies = {
      "nvim-lua/plenary.nvim"
    },
    keys = { { "<C-G>", ":Neogit" } }
  }
})
```

Disabling the basic autocommands solves the issue, but I’d like to still use them.

[Others have found](https://github.com/NeogitOrg/neogit/issues/426#issuecomment-1374833515) that changing the pattern to `term://*` stops the Neogit problem, and keeps the autocommand working, which is the method that this PR uses.