### PR TITLE
(mini.files) FEATURE: Add MiniFiles.toggle()

### DIFF
--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -683,16 +683,7 @@ Return~
                 `MiniFiles.toggle`({path}, {use_latest}, {opts})
 Toggle file explorer
 
-Parameters~
-{path} `(string|nil)` A valid file system path used as anchor.
-  If it is a path to directory, used directly.
-  If it is a path to file, its parent directory is used as anchor while
-  explorer will focus on the supplied file.
-  Default: path of |current-directory|.
-{use_latest} `(boolean|nil)` Whether to load explorer state from history
-  (based on the supplied anchor path). Default: `true`.
-{opts} `(table|nil)` Table of options overriding |MiniFiles.config| and
-  `vim.b.minifiles_config` for this particular explorer session.
+Uses the same input parameters as |MiniFiles.open()|
 
 ------------------------------------------------------------------------------
                                                              *MiniFiles.go_in()*

--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -680,9 +680,19 @@ Return~
 
 ------------------------------------------------------------------------------
                                                             *MiniFiles.toggle()*
-                              `MiniFiles.toggle`()
-Toggle explorer
+                `MiniFiles.toggle`({path}, {use_latest}, {opts})
+Toggle file explorer
 
+Parameters~
+{path} `(string|nil)` A valid file system path used as anchor.
+  If it is a path to directory, used directly.
+  If it is a path to file, its parent directory is used as anchor while
+  explorer will focus on the supplied file.
+  Default: path of |current-directory|.
+{use_latest} `(boolean|nil)` Whether to load explorer state from history
+  (based on the supplied anchor path). Default: `true`.
+{opts} `(table|nil)` Table of options overriding |MiniFiles.config| and
+  `vim.b.minifiles_config` for this particular explorer session.
 
 ------------------------------------------------------------------------------
                                                              *MiniFiles.go_in()*

--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -679,6 +679,12 @@ Return~
 `(boolean|nil)` Whether closing was done or `nil` if there was nothing to close.
 
 ------------------------------------------------------------------------------
+                                                            *MiniFiles.toggle()*
+                              `MiniFiles.toggle`()
+Toggle explorer
+
+
+------------------------------------------------------------------------------
                                                              *MiniFiles.go_in()*
                               `MiniFiles.go_in`()
 Go in entry under cursor

--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -799,6 +799,14 @@ MiniFiles.close = function()
   return true
 end
 
+
+--- Toggle explorer
+---
+MiniFiles.toggle = function()
+  local explorer = H.explorer_get()
+  if explorer == nil then MiniFiles.open() else MiniFiles.close() end
+end
+
 --- Go in entry under cursor
 ---
 --- Depends on entry under cursor:

--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -802,15 +802,7 @@ end
 
 --- Toggle file explorer
 ---
----@param path string|nil A valid file system path used as anchor.
----   If it is a path to directory, used directly.
----   If it is a path to file, its parent directory is used as anchor while
----   explorer will focus on the supplied file.
----   Default: path of |current-directory|.
----@param use_latest boolean|nil Whether to load explorer state from history
----   (based on the supplied anchor path). Default: `true`.
----@param opts table|nil Table of options overriding |MiniFiles.config| and
----   `vim.b.minifiles_config` for this particular explorer session.
+--- Uses the same input parameters as |MiniFiles.open()|
 MiniFiles.toggle = function(path, use_latest, opts)
   local explorer = H.explorer_get()
   if explorer == nil then MiniFiles.open(path, use_latest, opts) else MiniFiles.close() end

--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -800,11 +800,20 @@ MiniFiles.close = function()
 end
 
 
---- Toggle explorer
+--- Toggle file explorer
 ---
-MiniFiles.toggle = function()
+---@param path string|nil A valid file system path used as anchor.
+---   If it is a path to directory, used directly.
+---   If it is a path to file, its parent directory is used as anchor while
+---   explorer will focus on the supplied file.
+---   Default: path of |current-directory|.
+---@param use_latest boolean|nil Whether to load explorer state from history
+---   (based on the supplied anchor path). Default: `true`.
+---@param opts table|nil Table of options overriding |MiniFiles.config| and
+---   `vim.b.minifiles_config` for this particular explorer session.
+MiniFiles.toggle = function(path, use_latest, opts)
   local explorer = H.explorer_get()
-  if explorer == nil then MiniFiles.open() else MiniFiles.close() end
+  if explorer == nil then MiniFiles.open(path, use_latest, opts) else MiniFiles.close() end
 end
 
 --- Go in entry under cursor


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Hi @echasnovski ,

Thanks for this genius plugin! Do you think it makes sense to include a `toggle` functionality? This way, we'd only need one binding to open/close the explorer (and avoid the risk of recording a macro when pressing `q` too much).

Please let me know what you think, feel free to close this PR if not needed.

Thanks and best regards,
David