### PR TITLE
(mini.pair) fix: prevent `'` from inserting after `&` character

### DIFF
--- a/lua/mini/pairs.lua
+++ b/lua/mini/pairs.lua
@@ -121,7 +121,7 @@ MiniPairs.config = {
   -- - <action> - one of "open", "close", "closeopen".
   -- - <pair> - two character string for pair to be used.
   -- By default pair is not inserted after `\`, quotes are not recognized by
-  -- `<CR>`, `'` does not insert pair after a letter.
+  -- `<CR>`, `'` does not insert pair after a letter or `&`.
   -- Only parts of tables can be tweaked (others will use these defaults).
   -- Supply `false` instead of table to not map particular key.
   mappings = {
@@ -134,7 +134,7 @@ MiniPairs.config = {
     ['}'] = { action = 'close', pair = '{}', neigh_pattern = '[^\\].' },
 
     ['"'] = { action = 'closeopen', pair = '""', neigh_pattern = '[^\\].', register = { cr = false } },
-    ["'"] = { action = 'closeopen', pair = "''", neigh_pattern = '[^%a\\].', register = { cr = false } },
+    ["'"] = { action = 'closeopen', pair = "''", neigh_pattern = '[^%a\\&].', register = { cr = false } },
     ['`'] = { action = 'closeopen', pair = '``', neigh_pattern = '[^\\].', register = { cr = false } },
   },
 }

--- a/tests/test_pairs.lua
+++ b/tests/test_pairs.lua
@@ -297,7 +297,7 @@ T['setup()']['creates `config` field'] = function()
   )
   expect_config(
     'mappings["\'"]',
-    { action = 'closeopen', pair = "''", neigh_pattern = '[^%a\\].', register = { cr = false } }
+    { action = 'closeopen', pair = "''", neigh_pattern = '[^%a\\&].', register = { cr = false } }
   )
   expect_config(
     "mappings['`']",
@@ -362,7 +362,7 @@ T['setup()']['makes default `config.mappings`'] = function()
   eq(has_map(']', [[v:lua.MiniPairs.close("[]", "[^\\].")]]), true)
   eq(has_map('}', [[v:lua.MiniPairs.close("{}", "[^\\].")]]), true)
   eq(has_map('"', [[v:lua.MiniPairs.closeopen('""', "[^\\].")]]), true)
-  eq(has_map("'", [[v:lua.MiniPairs.closeopen("''", "[^%a\\].")]]), true)
+  eq(has_map("'", [[v:lua.MiniPairs.closeopen("''", "[^%a\\&].")]]), true)
   eq(has_map('`', [[v:lua.MiniPairs.closeopen("``", "[^\\].")]]), true)
 
   eq(has_map('<CR>', 'v:lua.MiniPairs.cr()'), true)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
