### PR TITLE
(mini.starter) Feature: exposed path string configuration via path_modifier parameter

### DIFF
--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -490,12 +490,16 @@ end
 ---   directory and its subdirectories. Default: `false`.
 ---@param show_path boolean|nil Whether to append file name with its full path.
 ---   Default: `true`.
+---@param path_modifier function|nil Modifier to apply to full path of file name.
+---   Expected to be function that accepts a string and returns a string
+---   Default: 'nil'.
 ---
 ---@return __starter_section_fun
-MiniStarter.sections.recent_files = function(n, current_dir, show_path)
+MiniStarter.sections.recent_files = function(n, current_dir, show_path, path_modifier)
   n = n or 5
   if current_dir == nil then current_dir = false end
   if show_path == nil then show_path = true end
+  if path_modifier == nil then path_modifier = (function(str) return str end) end
 
   return function()
     local section = ('Recent files%s'):format(current_dir and ' (current directory)' or '')
@@ -523,7 +527,7 @@ MiniStarter.sections.recent_files = function(n, current_dir, show_path)
     local items = {}
     local fmodify = vim.fn.fnamemodify
     for _, f in ipairs(vim.list_slice(files, 1, n)) do
-      local path = show_path and (' (%s)'):format(fmodify(f, ':~:.')) or ''
+      local path = show_path and (' (%s)'):format(path_modifier(fmodify(f, ':~:.'))) or ''
       local name = ('%s%s'):format(fmodify(f, ':t'), path)
       table.insert(items, { action = ('edit %s'):format(fmodify(f, ':p')), name = name, section = section })
     end


### PR DESCRIPTION
Feature:

This patch adds a `path_modifier` parameter to MiniStarter.sections.recent_files which changes the way `path` is displayed. This defaults to `nil`, which is redefined as `function(x) return x end`.

By exposing the `path` variable via the `path_modifier` parameter, one can change how the `path` for each file is displayed, such as shortening the path. See below for a potential use case:

```
local function path_modifier(str, max_count)
    -- can use vim.regex() for this...
    local tail = vim.fn.fnamemodify(str, ":t")
    local head = vim.fn.fnamemodify(str, ":h")
    local new_str = ""
    local count = 0
    if head == nil or #head <= max_count then
        return str
    else
        for c in string.gmatch(head, '.') do
            if c == "/" then
                count = 0
            end
            if count < max_count then
                new_str = new_str .. c
                count = count + 1
            end
        end
    end
    new_str = new_str .. "/"
    return new_str .. tail
end
require("mini.starter").setup({
    items = {
        starter.sections.recent_files(.., .., .., function(x) return path_modifier(x, 4) end),
    },
})

```

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
