### PR TITLE
(mini.test) Add `child.lua_func()` method

### DIFF
--- a/doc/mini-test.txt
+++ b/doc/mini-test.txt
@@ -760,6 +760,8 @@ Fields~
 {lua} `(function)` Execute Lua code. A wrapper for |nvim_exec_lua()|.
 {lua_get} `(function)` Execute Lua code and return result. A wrapper
   for |nvim_exec_lua()| but prepends string code with `return`.
+{lua_func} `(function)` Execute Lua function and return it's result.
+  Function will be called with all extra parameters of lua_func(). No upvalues.
 
 {is_blocked} `(function)` Check whether child process is blocked.
 {is_running} `(function)` Check whether child process is currently running.

--- a/lua/mini/test.lua
+++ b/lua/mini/test.lua
@@ -1287,6 +1287,15 @@ MiniTest.new_child_neovim = function()
     return child.api.nvim_exec_lua('return ' .. str, args or {})
   end
 
+  child.lua_func = function(f, ...)
+    ensure_running()
+    prevent_hanging('lua_func')
+    return child.api.nvim_exec_lua(
+      'local f = ...; return assert(loadstring(f))(select(2, ...))',
+      { string.dump(f), ... }
+    )
+  end
+
   child.is_blocked = function()
     ensure_running()
     return child.api.nvim_get_mode()['blocking']
@@ -1400,6 +1409,8 @@ end
 ---@field lua function Execute Lua code. A wrapper for |nvim_exec_lua()|.
 ---@field lua_get function Execute Lua code and return result. A wrapper
 ---   for |nvim_exec_lua()| but prepends string code with `return`.
+---@field lua_func function Execute Lua function and return it's result.
+---   Function will be called with all extra parameters of lua_func(). No upvalues.
 ---
 ---@field is_blocked function Check whether child process is blocked.
 ---@field is_running function Check whether child process is currently running.

--- a/tests/test_test.lua
+++ b/tests/test_test.lua
@@ -1099,6 +1099,37 @@ T['child']['lua_get()'] = function()
   validate_child_method(method, { name = 'lua_get' })
 end
 
+T['child']['lua_func()'] = function()
+  -- Can execute functions in child neovim
+  local method = function()
+    return child.lua_func(function() _G.n = 0 end)
+  end
+
+  eq(child.lua_get('_G.n'), vim.NIL)
+  method()
+  eq(child.lua_get('_G.n'), 0)
+
+  -- Can return values
+  method = function()
+    return child.lua_func(function() return 1 + 1 end)
+  end
+  eq(method(), 2)
+
+  -- Can error
+  method = function()
+    return child.lua_func(function() error('test error') end)
+  end
+  expect.error(method, 'test error')
+
+  -- Can take arguments
+  method = function()
+    return child.lua_func(function(a, b) return a + b end, 1, 2)
+  end
+  eq(method(), 3)
+
+  validate_child_method(method, { name = 'lua_func' })
+end
+
 T['child']['is_blocked()'] = function()
   eq(child.is_blocked(), false)
 


### PR DESCRIPTION
I like `mini.test`, but I don't particularly like to write lua code as strings, because it looses syntax highlighting/code completion/type checking etc. I started to use this little function and I think it works pretty well. I thought that I can contribute it here.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
