### PR TITLE
(mini.clue) Fix default register check for unnamedplus

### DIFF
--- a/lua/mini/clue.lua
+++ b/lua/mini/clue.lua
@@ -1903,8 +1903,8 @@ end
 
 H.get_default_register = function()
   local clipboard = vim.o.clipboard
-  if clipboard:find('unnamed') ~= nil then return '*' end
   if clipboard:find('unnamedplus') ~= nil then return '+' end
+  if clipboard:find('unnamed') ~= nil then return '*' end
   return '"'
 end
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

`unnamedplus` is never resolved because it already contains `unnamed`.