### PR TITLE
(mini.bufremove) Feature: Configurable fallback on delete last buffer

### DIFF
--- a/doc/mini-bufremove.txt
+++ b/doc/mini-bufremove.txt
@@ -29,7 +29,8 @@ To stop module from showing non-error feedback, set `config.silent = true`.
    decided by the algorithm:
    - If alternate buffer (see |CTRL-^|) is listed (see |buflisted()|), use it.
    - If previous listed buffer (see |bprevious|) is different, use it.
-   - Otherwise create a new one with `nvim_create_buf(true, false)` and use it.
+   - Otherwise use fallback function `config.on_delete_last_fallback(win_id)`.
+     (Default is to create a scratch one with `nvim_create_buf(true, false)`)
 
 # Disabling~
 
@@ -58,6 +59,13 @@ Module config
 Default values:
 >
   MiniBufremove.config = {
+    -- Fallback function when deleting last buffer
+    on_delete_last_fallback = function(win_id)
+      -- Create new listed scratch buffer
+      local new_buf = vim.api.nvim_create_buf(true, false)
+      vim.api.nvim_win_set_buf(win_id, new_buf)
+    end,
+
     -- Whether to set Vim's settings for buffers (allow hidden buffers)
     set_vim_settings = true,
 

--- a/lua/mini/bufremove.lua
+++ b/lua/mini/bufremove.lua
@@ -29,7 +29,8 @@
 ---    decided by the algorithm:
 ---    - If alternate buffer (see |CTRL-^|) is listed (see |buflisted()|), use it.
 ---    - If previous listed buffer (see |bprevious|) is different, use it.
----    - Otherwise create a new one with `nvim_create_buf(true, false)` and use it.
+---    - Otherwise use fallback function `config.on_delete_last_fallback(win_id)`.
+---      (Default is to create a scratch one with `nvim_create_buf(true, false)`)
 ---
 --- # Disabling~
 ---
@@ -70,6 +71,13 @@ end
 --- Default values:
 ---@eval return MiniDoc.afterlines_to_code(MiniDoc.current.eval_section)
 MiniBufremove.config = {
+  -- Fallback function when deleting last buffer
+  on_delete_last_fallback = function(win_id)
+    -- Create new listed scratch buffer
+    local new_buf = vim.api.nvim_create_buf(true, false)
+    vim.api.nvim_win_set_buf(win_id, new_buf)
+  end,
+
   -- Whether to set Vim's settings for buffers (allow hidden buffers)
   set_vim_settings = true,
 
@@ -156,9 +164,8 @@ MiniBufremove.unshow_in_window = function(win_id)
     local has_previous = pcall(vim.cmd, 'bprevious')
     if has_previous and cur_buf ~= vim.api.nvim_win_get_buf(win_id) then return end
 
-    -- Create new listed buffer
-    local new_buf = vim.api.nvim_create_buf(true, false)
-    vim.api.nvim_win_set_buf(win_id, new_buf)
+    -- Do configured fallback
+    MiniBufremove.config.on_delete_last_fallback(win_id)
   end)
 
   return true


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

I took a default and made it configurable.

I utilize this in my own config of mini.bufremove:

```lua
{
  "echasnovski/mini.bufremove",
  dev = true, -- Remove once PR is accepted
  opts = {
    on_delete_last_fallback = function(_)
      local orig_cwd = os.getenv("PWD")
      vim.fn.chdir(orig_cwd)
      vim.cmd("SessionDelete")
      vim.cmd("Alpha")
    end,
  },
}
```