### PR TITLE
(mini.hues) Fix terminal colors

### DIFF
--- a/lua/mini/hues.lua
+++ b/lua/mini/hues.lua
@@ -1425,14 +1425,14 @@ H.apply_colorscheme = function(config)
   vim.g.terminal_color_5  = p.purple
   vim.g.terminal_color_6  = p.cyan
   vim.g.terminal_color_7  = p.fg
-  vim.g.terminal_color_8  = p.bg
-  vim.g.terminal_color_9  = p.red
-  vim.g.terminal_color_10 = p.green
-  vim.g.terminal_color_11 = p.yellow
-  vim.g.terminal_color_12 = p.azure
-  vim.g.terminal_color_13 = p.purple
-  vim.g.terminal_color_14 = p.cyan
-  vim.g.terminal_color_15 = p.fg
+  vim.g.terminal_color_8  = p.bg_mid2
+  vim.g.terminal_color_9  = p.red_mid2
+  vim.g.terminal_color_10 = p.green_mid2
+  vim.g.terminal_color_11 = p.yellow_mid2
+  vim.g.terminal_color_12 = p.azure_mid2
+  vim.g.terminal_color_13 = p.purple_mid2
+  vim.g.terminal_color_14 = p.cyan_mid2
+  vim.g.terminal_color_15 = p.fg_mid2
 end
 
 -- Color conversion -----------------------------------------------------------


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

This PR aim to fix the following:

![20231008_18h12m49s_screenshot](https://github.com/echasnovski/mini.nvim/assets/44581623/67fe7269-5f96-408c-8361-17bae7815859)
![20231008_18h11m22s_screenshot](https://github.com/echasnovski/mini.nvim/assets/44581623/f7cdc063-2ffe-42f2-9c49-82bbdf29d0ec)
