### PR TITLE
(mini.map) FEATURE: Adds zindex as window option

### DIFF
--- a/doc/mini-map.txt
+++ b/doc/mini-map.txt
@@ -218,6 +218,9 @@ Default values:
 
       -- Value of 'winblend' option
       winblend = 25,
+
+      -- Z-index of map window
+      zindex = 10,
     },
   }
 <
@@ -341,6 +344,8 @@ integration count column. Default: 10.
 `window.winblend` - value of 'winblend' for map window. Value 0 makes it
 completely non-transparent, 100 - completely transparent (content is still
 visible, but with slightly different highlights).
+
+`window.zindex` - value of 'zindex' for map window. Default: 10.
 
 # Pure scrollbar config ~
 

--- a/lua/mini/map.lua
+++ b/lua/mini/map.lua
@@ -328,6 +328,8 @@ end
 --- completely non-transparent, 100 - completely transparent (content is still
 --- visible, but with slightly different highlights).
 ---
+--- `window.zindex` - value of 'zindex' for map window. Default: 10.
+---
 --- # Pure scrollbar config ~
 ---
 --- "Pure scrollbar" is a configuration when window width is not enough to show
@@ -385,6 +387,9 @@ MiniMap.config = {
 
     -- Value of 'winblend' option
     winblend = 25,
+
+    -- Z-index of map window
+    zindex = 10,
   },
 }
 --minidoc_afterlines_end
@@ -1313,10 +1318,10 @@ H.normalize_window_options = function(win_opts, full)
     -- Can be updated at `VimResized` event
     height = vim.o.lines - vim.o.cmdheight - (has_tabline and 1 or 0) - (has_statusline and 1 or 0),
     focusable = win_opts.focusable,
+    zindex = win_opts.zindex,
   }
   if not full then return res end
 
-  res.zindex = 10
   res.style = 'minimal'
   return res
 end

--- a/tests/test_map.lua
+++ b/tests/test_map.lua
@@ -410,7 +410,7 @@ end
 T['open()']['respects `opts.window` argument'] = function()
   set_lines(example_lines)
   local opts =
-    { window = { focusable = true, side = 'left', show_integration_count = false, width = 15, winblend = 50 } }
+    { window = { focusable = true, side = 'left', show_integration_count = false, width = 15, winblend = 50, zindex = 10 } }
   map_open(opts)
 
   child.expect_screenshot()
@@ -648,7 +648,7 @@ T['refresh()']['respects `opts.window` argument'] = function()
   map_open()
 
   local opts =
-    { window = { focusable = true, side = 'left', show_integration_count = false, width = 15, winblend = 50 } }
+    { window = { focusable = true, side = 'left', show_integration_count = false, width = 15, winblend = 50, zindex = 10 } }
   map_refresh(opts)
 
   child.expect_screenshot()


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [X] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Needed this to avoid orchestrating my other floats around the default 10 z-index. [nvim-treesitter-context](https://github.com/nvim-treesitter/nvim-treesitter-context) has a default of 20 so anyone installing it would run into this issue.

I'm currently using a [fork](https://github.com/nolantait/mini.map) of this on my [configs](https://github.com/nolantait/dotfiles/blob/a0c754859046d513ea6c0ce7ee89b74e4b839f8c/config/nvim/lua/plugins/configs/mini-map.lua#L43) and its working great.
