### PR TITLE
Basics: enhance window resize logic

### DIFF
--- a/lua/mini/basics.lua
+++ b/lua/mini/basics.lua
@@ -646,10 +646,10 @@ H.apply_mappings = function(config)
     map('n', '<C-L>', '<C-w>l', { desc = 'Focus on right window' })
 
     -- Window resize (respecting `v:count`)
-    map('n', '<C-Left>',  '"<Cmd>vertical resize -" . v:count1 . "<CR>"', { expr = true, replace_keycodes = false, desc = 'Decrease window width' })
-    map('n', '<C-Down>',  '"<Cmd>resize -"          . v:count1 . "<CR>"', { expr = true, replace_keycodes = false, desc = 'Decrease window height' })
-    map('n', '<C-Up>',    '"<Cmd>resize +"          . v:count1 . "<CR>"', { expr = true, replace_keycodes = false, desc = 'Increase window height' })
-    map('n', '<C-Right>', '"<Cmd>vertical resize +" . v:count1 . "<CR>"', { expr = true, replace_keycodes = false, desc = 'Increase window width' })
+    map('n', '<C-Left>',  '(v:count ? "" : 4) . (winnr() == winnr("l") ? "<C-w>>" : "<C-w><")', { expr = true, replace_keycodes = false, desc = 'Decrease window width' })
+    map('n', '<C-Down>',  '(v:count ? "<C-w>-" : "1<C-w>-")', { expr = true, replace_keycodes = false, desc = 'Decrease window height' })
+    map('n', '<C-Up>',    '(v:count ? "<C-w>+" : "1<C-w>+")', { expr = true, replace_keycodes = false, desc = 'Increase window height' })
+    map('n', '<C-Right>', '(v:count ? "" : 4) . (winnr() == winnr("l") ? "<C-w><" : "<C-w>>")', { expr = true, replace_keycodes = false, desc = 'Increase window width' })
   end
 
   if config.mappings.move_with_alt then


### PR DESCRIPTION
Window resizing was a bit confusing, with left sometimes behaving like right and right sometimes behaving like left. This was not in line with user expectations. This PR enhance the logic behind, ensuring that left remains left and right remains right, similar to how it works for "nN" and "Nn" and/or "gj" and "gk".


[Screencast from 2023-10-24 09-02-29.webm](https://github.com/echasnovski/mini.nvim/assets/91024200/a029c13a-e495-4ba6-8ea6-1d30f952446e)

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

>  The best way to do it is to receive a positive feedback from maintainer on your initiative in one of the GitHub issues (existing one or created by you otherwise). 

Sorry about that, I read this after the fact ^
