### PR TITLE
(mini.ai) Fix outdated treesitter query command in comment.

### DIFF
--- a/lua/mini/ai.lua
+++ b/lua/mini/ai.lua
@@ -877,7 +877,7 @@ end
 ---   your |$XDG_CONFIG_HOME| directory. It should contain queries with
 ---   captures (later used to define textobjects). See |lua-treesitter-query|.
 --- To verify that query file is reachable, run (example for "lua" language)
---- `:lua print(vim.inspect(vim.treesitter.get_query_files('lua', 'textobjects')))`
+--- `:lua print(vim.inspect(vim.treesitter.query.get_files('lua', 'textobjects')))`
 --- (output should have at least an intended file).
 ---
 --- Example configuration for function definition textobject with


### PR DESCRIPTION
While debugging `mini.ai` I discovered this command and saw that it is referring to a deprecated treesitter command. With this change, the documentation will be accurate again.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
