### PR TITLE
(mini.completion) Update `set_vim_settings`'s `shortmess` to hide completion messages

### DIFF
--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -531,7 +531,11 @@ H.apply_config = function(config)
 
   if config.set_vim_settings then
     -- Don't give ins-completion-menu messages
-    vim.opt.shortmess:append('c')
+    if vim.fn.has('nvim-0.9') == 1 then
+      vim.opt.shortmess:append('cC')
+    else
+      vim.opt.shortmess:append('c')
+    end
     -- More common completion behavior
     vim.o.completeopt = 'menuone,noinsert,noselect'
   end

--- a/tests/test_completion.lua
+++ b/tests/test_completion.lua
@@ -197,6 +197,9 @@ end
 T['setup()']['respects `config.set_vim_settings`'] = function()
   reload_module({ set_vim_settings = true })
   expect.match(child.api.nvim_get_option('shortmess'), 'c')
+  if child.fn.has('nvim-0.9') == 1 then
+    expect.match(child.api.nvim_get_option('shortmess'), 'C')
+  end
   eq(child.api.nvim_get_option('completeopt'), 'menuone,noinsert,noselect')
 end
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Right now, mini.completion adds "c" to `shortmess` when `set_vim_settings` is enabled to reduce the amount of command line messages printed when completing. This PR also adds "C" to `shortmess` to further silence unnecessary messages. This has also already been referenced in https://github.com/echasnovski/mini.nvim/issues/5#issuecomment-1278554178 before. I've changed the code so that it detects to see if the user is using Neovim 0.9.0 or newer before adding the flag, and I also edited the appropriate tests.