### PR TITLE
(mini.misc) FEATURE: implement `setup_mkdir_missing()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 ## mini.completion
 
-- FEATURE: Start adding `C` flag to `shortmess` option on Neovim>=0.9.
+- FEATURE: Start adding `C` flag to `shortmess` option on Neovim>=0.9. (@yamin-shihab, PR #554)
 
 ## mini.extra
 
@@ -50,6 +50,7 @@ Introduction of a new module.
 
 ## mini.misc
 
+- FEATURE: Add `MiniMisc.setup_mkdir_missing()` for automatically creating missing directories before every save. (@yamin-shihab, PR #555)
 - FEATURE: `setup_auto_root()` and `find_root()` now have `fallback` argument to be applied when no root is found with `vim.fn.find()`.
 
 ## mini.pick

--- a/doc/mini-misc.txt
+++ b/doc/mini-misc.txt
@@ -166,6 +166,20 @@ Parameters~
   a valid directory path.
 
 ------------------------------------------------------------------------------
+                                                *MiniMisc.setup_mkdir_missing()*
+                        `MiniMisc.setup_mkdir_missing`()
+Automatically create any missing directories before every save
+
+When saving a file located in a directory that doesn't exist, this will create
+that directory and any other missing directories in between so that the file
+saves properly. This also works with netrw URls; see |netrw-transparent| for
+details.
+
+Usage~
+>
+  require('mini.misc').setup_mkdir_missing()
+
+------------------------------------------------------------------------------
                                                *MiniMisc.setup_restore_cursor()*
                     `MiniMisc.setup_restore_cursor`({opts})
 Restore cursor position on file open

--- a/lua/mini/misc.lua
+++ b/lua/mini/misc.lua
@@ -283,6 +283,32 @@ end
 
 H.root_cache = {}
 
+--- Automatically create any missing directories before every save
+---
+--- When saving a file located in a directory that doesn't exist, this will create
+--- that directory and any other missing directories in between so that the file
+--- saves properly. This also works with netrw URls; see |netrw-transparent| for
+--- details.
+---
+---@usage >
+---   require('mini.misc').setup_mkdir_missing()
+MiniMisc.setup_mkdir_missing = function()
+  -- Create autocommand which runs on every `BufWrite`
+  local augroup = vim.api.nvim_create_augroup('MiniMiscMkdirMissing', {})
+  vim.api.nvim_create_autocmd('BufWrite', {
+    group = augroup,
+    callback = function()
+      local dir = vim.fn.expand('<afile>:p:h')
+
+      -- Correctly handle URLs using netrw
+      -- Source: https://github.com/jghauser/mkdir.nvim/pull/7
+      if dir:find('%l+://') == 1 then return end
+
+      if vim.fn.isdirectory(dir) == 0 then vim.fn.mkdir(dir, 'p') end
+    end,
+  })
+end
+
 --- Restore cursor position on file open
 ---
 --- When reopening a file this will make sure the cursor is placed back to the

--- a/readmes/mini-misc.md
+++ b/readmes/mini-misc.md
@@ -29,6 +29,7 @@ https://user-images.githubusercontent.com/24854248/173044891-69b0ccfd-3fe8-4639-
 - `bench_time()` executes function several times and timing how long it took.
 - `put()` and `put_text()` print Lua objects in command line and current buffer respectively.
 - `setup_auto_root()` sets up automated change of current directory.
+- `setup_mkdir_missing()` sets up automated creation of missing directories on file save.
 - `setup_restore_cursor()` sets up automated restoration of cursor position on file reopen.
 - `stat_summary()` computes summary statistics of numerical array.
 - `tbl_head()` and `tbl_tail()` return first and last elements of table.

--- a/tests/dir-misc/init-mkdir-missing.lua
+++ b/tests/dir-misc/init-mkdir-missing.lua
@@ -1,0 +1,3 @@
+dofile('scripts/minimal_init.lua')
+
+require('mini.misc').setup_mkdir_missing()

--- a/tests/test_misc.lua
+++ b/tests/test_misc.lua
@@ -474,6 +474,27 @@ T['find_root()']['uses cache'] = function()
   eq(find_root(), dir_misc_path)
 end
 
+local mkdir_missing_test_file = make_path(dir_misc_path, 'mkdir-missing/nested/mkdir-missing.lua')
+local mkdir_missing_test_directory = make_path(dir_misc_path, 'mkdir-missing')
+local mkdir_missing_init_file = make_path(dir_misc_path, 'init-mkdir-missing.lua')
+
+T['setup_mkdir_missing()'] = new_set({
+  hooks = {
+    post_case = function()
+      -- Clean up created directories
+      child.fn.delete(mkdir_missing_test_directory, 'rf')
+    end,
+  },
+})
+
+T['setup_mkdir_missing()']['works'] = function()
+  child.restart({ '-u', mkdir_missing_init_file, '--', mkdir_missing_test_file })
+  child.cmd('w')
+
+  -- Should create directory
+  eq(child.fn.isdirectory(mkdir_missing_test_directory), 1)
+end
+
 local restore_cursor_test_file = make_path(dir_misc_path, 'restore-cursor.lua')
 local restore_cursor_init_file = make_path(dir_misc_path, 'init-restore-cursor.lua')
 local restore_cursor_shada_path = make_path(dir_misc_path, 'restore-cursor.shada')


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

If this PR were to be merged, mini.misc will have the `setup_mkdir_missing()` function which will automatically create any missing directories needed for saving a file. This is similar to the functionality provided by [tidy.nvim](https://github.com/mcauley-penney/tidy.nvim). I also  made sure it didn't break with netrw URLs, and I wrote it some documentation and tests.