### PR TITLE
(mini.extra) Fix git pickers not working when repository path contains spaces

### DIFF
--- a/lua/mini/extra.lua
+++ b/lua/mini/extra.lua
@@ -1588,7 +1588,8 @@ end
 
 H.git_get_repo_dir = function(path, path_type, picker_name)
   local path_dir = path_type == 'directory' and path or vim.fn.fnamemodify(path, ':h')
-  local repo_dir = vim.fn.systemlist('git -C ' .. path_dir .. ' rev-parse --show-toplevel')[1]
+  local cmd = { 'git', '-C', path_dir, 'rev-parse', '--show-toplevel' }
+  local repo_dir = vim.fn.systemlist(cmd)[1]
   if vim.v.shell_error ~= 0 then
     local msg = string.format('`pickers.%s` could not find Git repo for %s.', picker_name, path)
     H.error(msg)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Some projects I work on are contained in a directory called 'My Projects'. Since the path is concatenated without  quotes, the `git -C` command fails.