### PR TITLE
(mini.surround) FEATURE: Add config.highlight_input to visualize target surrounding

### DIFF
--- a/doc/mini-surround.txt
+++ b/doc/mini-surround.txt
@@ -456,8 +456,11 @@ Default values:
     -- information with examples, see `:h MiniSurround.config`.
     custom_surroundings = nil,
 
-    -- Duration (in ms) of highlight when calling `MiniSurround.highlight()`
+    -- Duration (in ms) of highlight when calling `MiniSurround.highlight()` or when calling `MiniSurround.find()` with `highlight_input` option being `true`.
     highlight_duration = 500,
+
+    -- Highlight input surrounding when calling `MiniSurround.delete()` or `Mini.Surround.replace()`
+    highlight_input = false,
 
     -- Module mappings. Use `''` (empty string) to disable one.
     mappings = {


### PR DESCRIPTION
![2023-11-13 23-21-54 mkv](https://github.com/echasnovski/mini.nvim/assets/30277794/c5dd0907-69d5-4c78-81dd-353b0cff9b13)


- Default is `false`
- `true` will highlight the input surrounding in the following ways
  - `delete()`: until the input surrounding is deleted
  - `replace()`: until the output surrounding is determined
  - `find()`: for `config.highlight_duration`

---

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

