### PR TITLE
feat(ci): add automatic releases and publish to luarocks

### DIFF
--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,0 +1,25 @@
+name: Push to Luarocks
+
+on:
+  push:
+    tags:
+      - '*'
+  pull_request: # Tests a local luarocks install without publishing on PRs
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  luarocks-upload:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: LuaRocks Upload
+        uses: nvim-neorocks/luarocks-tag-release@v5
+        env:
+          LUAROCKS_API_KEY: ${{ secrets.LUAROCKS_API_KEY }}
+        with:
+          labels: |
+            neovim
+          detailed_description: |
+            Library of 30+ independent Lua modules improving overall Neovim (version 0.7 and higher) experience with minimal effort.
+            They all share same configuration approaches and general design principles.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+        with:
+          release-type: simple
+          package-name: mini.nvim


### PR DESCRIPTION
Hey buddy, hope you're doing well!

I've been using `mini.nvim` for a long time now and absolutely love it. We are little by little working on the adoption of LuaRocks and I would like `mini.nvim` to be present there :)

### Summary

This PR is part of a push to get Neovim plugins on [LuaRocks](https://luarocks.org/labels/neovim).

- See [this blog post](https://mrcjkb.github.io/posts/2023-01-10-luarocks-tag-release.html), which follows up on [a series of posts](https://teto.github.io/posts/2021-09-17-neovim-plugin-luarocks.html).
- See also: [`rocks.nvim`](https://github.com/nvim-neorocks/rocks.nvim), a new luarocks-based plugin manager.

### Things done:

- Add a [`release-please`](https://github.com/google-github-actions/release-please-action) workflow that creates release PRs with SemVer versioning based on conventional commits.
- Add a workflow that publishes tags to LuaRocks when a tag is pushed.

The workflows are based on [this guide](https://github.com/nvim-neorocks/sample-luarocks-plugin) by `@vhyrro`.

### Notes

- On each merge to `master`, the `release` workflow creates (or updates an existing) release PR.
- You decide when to merge release PRs. Doing so will result in a SemVer tag, and a GitHub release, which will trigger the `luarocks` workflow.
- For the luarocks workflow to work, someone with a `luarocks.org` account will have to add their [API key](https://luarocks.org/settings/api-keys) to this repo's [GitHub actions secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository), as mentioned in the guide mentioned above.