### PR TITLE
(mini.files) Expose `go_in_plus()` and `go_out_plus()`

### DIFF
--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -700,11 +700,21 @@ Depends on entry under cursor:
   Explorer is not closed after that.
 
 ------------------------------------------------------------------------------
+                                                        *MiniFiles.go_in_plus()*
+                            `MiniFiles.go_in_plus`()
+Like |MiniFiles.go_in()|, but closes explorer after opening a file.
+
+------------------------------------------------------------------------------
                                                             *MiniFiles.go_out()*
                               `MiniFiles.go_out`()
 Go out to parent directory
 
 - Focus on window to the left showing parent of current directory.
+
+------------------------------------------------------------------------------
+                                                       *MiniFiles.go_out_plus()*
+                           `MiniFiles.go_out_plus`()
+Like |MiniFiles.go_out()|, but trims the right part of the branch.
 
 ------------------------------------------------------------------------------
                                                          *MiniFiles.trim_left()*

--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -832,6 +832,17 @@ MiniFiles.go_in = function()
   H.explorer_refresh(explorer)
 end
 
+--- Like |MiniFiles.go_in()|, but closes explorer after opening a file.
+MiniFiles.go_in_plus = function()
+  for _ = 1, vim.v.count1 - 1 do
+    MiniFiles.go_in()
+  end
+  local fs_entry = MiniFiles.get_fs_entry()
+  local is_at_file = fs_entry ~= nil and fs_entry.fs_type == 'file'
+  MiniFiles.go_in()
+  if is_at_file then MiniFiles.close() end
+end
+
 --- Go out to parent directory
 ---
 --- - Focus on window to the left showing parent of current directory.
@@ -847,6 +858,15 @@ MiniFiles.go_out = function()
 
   H.explorer_refresh(explorer)
 end
+
+--- Like |MiniFiles.go_out()|, but trims the right part of the branch.
+MiniFiles.go_out_plus = function()
+  for _ = 1, vim.v.count1 do
+    MiniFiles.go_out()
+  end
+  MiniFiles.trim_right()
+end
+
 
 --- Trim left part of branch
 ---
@@ -1851,25 +1871,10 @@ H.buffer_make_mappings = function(buf_id, mappings)
     end
   end
 
-  local go_in_plus = function()
-    for _ = 1, vim.v.count1 - 1 do
-      MiniFiles.go_in()
-    end
-    local fs_entry = MiniFiles.get_fs_entry()
-    local is_at_file = fs_entry ~= nil and fs_entry.fs_type == 'file'
-    MiniFiles.go_in()
-    if is_at_file then MiniFiles.close() end
-  end
-
   local go_out_with_count = function()
     for _ = 1, vim.v.count1 do
       MiniFiles.go_out()
     end
-  end
-
-  local go_out_plus = function()
-    go_out_with_count()
-    MiniFiles.trim_right()
   end
 
   local go_in_visual = function()
@@ -1897,9 +1902,9 @@ H.buffer_make_mappings = function(buf_id, mappings)
   --stylua: ignore start
   buf_map('n', mappings.close,       MiniFiles.close,       'Close')
   buf_map('n', mappings.go_in,       go_in_with_count,      'Go in entry')
-  buf_map('n', mappings.go_in_plus,  go_in_plus,            'Go in entry plus')
+  buf_map('n', mappings.go_in_plus,  MiniFiles.go_in_plus,  'Go in entry plus')
   buf_map('n', mappings.go_out,      go_out_with_count,     'Go out of directory')
-  buf_map('n', mappings.go_out_plus, go_out_plus,           'Go out of directory plus')
+  buf_map('n', mappings.go_out_plus, MiniFiles.go_out_plus, 'Go out of directory plus')
   buf_map('n', mappings.reset,       MiniFiles.reset,       'Reset')
   buf_map('n', mappings.reveal_cwd,  MiniFiles.reveal_cwd,  'Reveal cwd')
   buf_map('n', mappings.show_help,   MiniFiles.show_help,   'Show Help')


### PR DESCRIPTION
Expose the "plus" variants of `go_in` and `go_out` so that users may
create multiple mappings to these actions.

It is not currently possible to map more than one key to these actions
without implementing their behavior manually, since the only way to map
a key to these actions is through the `mappings` table of the `setup()`
call, which does not support mapping multiple keys to a single action.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
