### PR TITLE
(mini.hues) Update CoC diagnostic highlight to link DiagnosticUnderline

### DIFF
--- a/lua/mini/base16.lua
+++ b/lua/mini/base16.lua
@@ -1005,21 +1005,6 @@ H.apply_palette = function(palette, use_cterm)
   end
 
   if H.has_integration('neoclide/coc.nvim') then
-    hi('CocErrorHighlight',   {link='DiagnosticError'})
-    hi('CocHintHighlight',    {link='DiagnosticHint'})
-    hi('CocInfoHighlight',    {link='DiagnosticInfo'})
-    hi('CocWarningHighlight', {link='DiagnosticWarn'})
-
-    hi('CocErrorFloat',   {link='DiagnosticFloatingError'})
-    hi('CocHintFloat',    {link='DiagnosticFloatingHint'})
-    hi('CocInfoFloat',    {link='DiagnosticFloatingInfo'})
-    hi('CocWarningFloat', {link='DiagnosticFloatingWarn'})
-
-    hi('CocErrorSign',   {link='DiagnosticSignError'})
-    hi('CocHintSign',    {link='DiagnosticSignHint'})
-    hi('CocInfoSign',    {link='DiagnosticSignInfo'})
-    hi('CocWarningSign', {link='DiagnosticSignWarn'})
-
     hi('CocCodeLens',             {link='LspCodeLens'})
     hi('CocDisabled',             {link='Comment'})
     hi('CocMarkdownLink',         {fg=p.base0F, bg=nil,      attr=nil, sp=nil})

--- a/lua/mini/hues.lua
+++ b/lua/mini/hues.lua
@@ -1373,21 +1373,6 @@ H.apply_colorscheme = function(config)
   end
 
   if has_integration('neoclide/coc.nvim') then
-    hi('CocErrorHighlight',   { link='DiagnosticError' })
-    hi('CocHintHighlight',    { link='DiagnosticHint' })
-    hi('CocInfoHighlight',    { link='DiagnosticInfo' })
-    hi('CocWarningHighlight', { link='DiagnosticWarn' })
-
-    hi('CocErrorFloat',   { link='DiagnosticFloatingError' })
-    hi('CocHintFloat',    { link='DiagnosticFloatingHint' })
-    hi('CocInfoFloat',    { link='DiagnosticFloatingInfo' })
-    hi('CocWarningFloat', { link='DiagnosticFloatingWarn' })
-
-    hi('CocErrorSign',   { link='DiagnosticSignError' })
-    hi('CocHintSign',    { link='DiagnosticSignHint' })
-    hi('CocInfoSign',    { link='DiagnosticSignInfo' })
-    hi('CocWarningSign', { link='DiagnosticSignWarn' })
-
     hi('CocCodeLens',             { link='LspCodeLens' })
     hi('CocDisabled',             { link='Comment' })
     hi('CocMarkdownLink',         { fg=p.blue,   bg=nil })


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

![image](https://github.com/echasnovski/mini.nvim/assets/91024200/7861f720-09b3-4105-9b51-086217f951b8)

Closes #706