### PR TITLE
(mini.basics) Check diagnostic status with vim.diagnostic.is_disabled().

### DIFF
--- a/lua/mini/basics.lua
+++ b/lua/mini/basics.lua
@@ -361,7 +361,12 @@ MiniBasics.config = {
 ---@return string String indicator for new state. Similar to what |:set| `{option}?` shows.
 MiniBasics.toggle_diagnostic = function()
   local buf_id = vim.api.nvim_get_current_buf()
-  local buf_state = H.buffer_diagnostic_state[buf_id]
+  local buf_state
+  if vim.fn.has('nvim-0.9') == 0 then
+    buf_state = H.buffer_diagnostic_state[buf_id]
+  else
+    buf_state = not vim.diagnostic.is_disabled(buf_id)
+  end
   if buf_state == nil then buf_state = true end
 
   if buf_state then
@@ -371,7 +376,7 @@ MiniBasics.toggle_diagnostic = function()
   end
 
   local new_buf_state = not buf_state
-  H.buffer_diagnostic_state[buf_id] = new_buf_state
+  if vim.fn.has('nvim-0.9') == 0 then H.buffer_diagnostic_state[buf_id] = new_buf_state end
 
   return new_buf_state and '  diagnostic' or 'nodiagnostic'
 end
@@ -381,7 +386,7 @@ end
 H.default_config = vim.deepcopy(MiniBasics.config)
 
 -- Diagnostic state per buffer
-H.buffer_diagnostic_state = {}
+if vim.fn.has('nvim-0.9') == 0 then H.buffer_diagnostic_state = {} end
 
 -- Helper functionality =======================================================
 -- Settings -------------------------------------------------------------------


### PR DESCRIPTION
[Details:](url)
- Neovim>=0.9 provides this function, so when possible we can use this rather than having to assume that diagnostics are enabled.

Reference: https://github.com/neovim/neovim/releases/tag/v0.9.0

Just an idea I had, I believe tests will fail but I'm not clear on how to resolve.

A use case I had is wanting to load buffers with diagnostics initially disabled. When doing so, the toggle function doesn't work as expected because it assumes diagnostics will initially be enabled.

Example autocmd:
```lua
vim.api.nvim_create_autocmd("BufReadPost", {
  pattern = "*",
  callback = function()
    vim.diagnostic.disable(0)
  end,
})
```

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
