### PR TITLE
fix(pick): use `opts.kind` in `ui_select()` as fallback…

### DIFF
--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -1208,7 +1208,7 @@ MiniPick.ui_select = function(items, opts, on_choice)
     end)
   end
 
-  local source = { items = items_ext, name = opts.kind or opts.prompt, preview = preview, choose = choose }
+  local source = { items = items_ext, name = opts.prompt or opts.kind, preview = preview, choose = choose }
   local item = MiniPick.start({ source = source })
   if item == nil and was_aborted then on_choice(nil) end
 end


### PR DESCRIPTION
… instead of the first thing.
Fixes `vim.ui.select()` prompt in some plugins (such as nvim-tree).

- [X] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [X] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
