### PR TITLE
docs(surround): Fix mini-surround examples doc

### DIFF
--- a/doc/mini-surround.txt
+++ b/doc/mini-surround.txt
@@ -82,10 +82,10 @@ Regular mappings:
 
 Extended mappings (temporary force "prev"/"next" search methods):
 - `sdnf` - delete (`sd`) next (`n`) function call (`f`).
-- `srlf(` - replace (`sd`) last (`l`) function call (`f`) with padded
+- `srlf(` - replace (`sr`) last (`l`) function call (`f`) with padded
   bracket (`(`).
 - `2sfnt` - find (`sf`) second (2) next (`n`) tag (`t`).
-- `shl}` - highlight (`sh`) last (`l`) second (`2`) curly bracket (`}`).
+- `2shl}` - highlight (`sh`) last (`l`) second (`2`) curly bracket (`}`).
 
 # Comparisons ~
 


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [X] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
