### PR TITLE
feat(files): add support for dynamic buffer width

### DIFF
--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -535,10 +535,13 @@ Default values:
       -- Whether to show preview of file/directory under cursor
       preview = false,
       -- Width of focused window
+      -- If set to 0 width will be calculated based on the longest line in the buffer
       width_focus = 50,
       -- Width of non-focused window
+      -- If set to 0 width will be calculated based on the longest line in the buffer
       width_nofocus = 15,
       -- Width of preview window
+      -- If set to 0 width will be calculated based on the longest line in the buffer
       width_preview = 25,
     },
   }


### PR DESCRIPTION
Having just the focused buffer and a preview is my ideal setup but some file names tend to be long and can't be seen with fixed width limitation that currently exists.

This change introduces the ability to have dynamic buffer width which will be determined based on the longest line of that buffer.

With this feature added, my windows config is:
```lua
    windows = {
      -- Maximum number of windows to show side by side
      max_number = 2,
      -- Whether to show preview of file/directory under cursor
      preview = true,
      -- Width of focused window
      width_focus = 0,
      -- Width of non-focused window
      width_nofocus = 0,
      -- Width of preview window
      width_preview = 0,
    }
```

<img width="1728" alt="Screenshot 2024-04-04 at 00 14 56" src="https://github.com/echasnovski/mini.nvim/assets/1770709/c887d1b7-b373-49b9-8764-5d1a64828125">

As I'm using Mac, I couldn't add necessary tests

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
