### PR TITLE
fix(mini-starter): use scheme name for Starter buffer

### DIFF
--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -1336,7 +1336,7 @@ H.apply_buffer_options = function(buf_id)
 
   -- Set buffer name
   H.buffer_number = H.buffer_number + 1
-  local name = H.buffer_number <= 1 and 'Starter' or ('Starter_' .. H.buffer_number)
+  local name = H.buffer_number <= 1 and 'mini.starter://Starter' or ('mini.starter://Starter_' .. H.buffer_number)
   vim.api.nvim_buf_set_name(buf_id, name)
 
   -- Having `noautocmd` is crucial for performance: ~9ms without it, ~1.6ms with it


### PR DESCRIPTION
When using a session manager and in the off-chance that there's a real souce file named 'Starter' in the session, restoring the session with this file from mini.starter causes an [issue](https://github.com/echasnovski/mini.nvim/discussions/786)

This is because mini.starter buffer name conflicts with the real source file named Starter.

This can be avoided by using a scheme-like name for the starter buffer which is a common practice for buffers created by plugins.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
