### PR TITLE
Update 'coc.nvim' to distinguish LSP 'unused parameter' highlight.

### DIFF
--- a/lua/mini/base16.lua
+++ b/lua/mini/base16.lua
@@ -1015,6 +1015,7 @@ H.apply_palette = function(palette, use_cterm)
   if H.has_integration('neoclide/coc.nvim') then
     hi('CocCodeLens',             {link='LspCodeLens'})
     hi('CocDisabled',             {link='Comment'})
+    hi('CocFadeOut',              {link='Comment'})
     hi('CocMarkdownLink',         {fg=p.base0F, bg=nil,      attr=nil, sp=nil})
     hi('CocMenuSel',              {fg=nil,      bg=p.base02, attr=nil, sp=nil})
     hi('CocNotificationProgress', {link='CocMarkdownLink'})

--- a/lua/mini/hues.lua
+++ b/lua/mini/hues.lua
@@ -1383,6 +1383,7 @@ H.apply_colorscheme = function(config)
   if has_integration('neoclide/coc.nvim') then
     hi('CocCodeLens',             { link='LspCodeLens' })
     hi('CocDisabled',             { link='Comment' })
+    hi('CocFadeOut',              { link='Comment' })
     hi('CocMarkdownLink',         { fg=p.blue,   bg=nil })
     hi('CocMenuSel',              { fg=nil,      bg=p.bg_mid2 })
     hi('CocNotificationProgress', { link='CocMarkdownLink' })


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

#### Before:

![Screenshot from 2024-04-23 13-13-44](https://github.com/echasnovski/mini.nvim/assets/91024200/6b863af0-860e-4b24-aaa4-31149a64eae3)

![Screenshot from 2024-04-23 13-16-40](https://github.com/echasnovski/mini.nvim/assets/91024200/b5e7eedc-61fd-417a-89c1-7221b340772a)

#### After:

![Screenshot from 2024-04-23 13-14-11](https://github.com/echasnovski/mini.nvim/assets/91024200/c6821c95-09ec-4ee7-8b35-bab3a490b64d)

![Screenshot from 2024-04-23 13-17-06](https://github.com/echasnovski/mini.nvim/assets/91024200/d224cdf1-450a-46f1-87b3-4e8512fe5534)

