### PR TITLE
docs(map): add a "scrollbar with signs" config example

### DIFF
--- a/doc/mini-map.txt
+++ b/doc/mini-map.txt
@@ -57,7 +57,8 @@ What it doesn't do:
   |MiniMap.toggle_side()|. Works best with global statusline.
 - Provide autoopen functionality. Due to vast differences in user preference
   of when map window should be shown, set up of automatic opening is left to
-  user. A common approach would be to call `MiniMap.open()` on |VimEnter| event.
+  user. A common approach would be to call `MiniMap.open()` on |VimEnter| or
+  |UIEnter| event.
   If you use |MiniStarter|, you can modify `<CR>` buffer mapping: >
 
   vim.cmd([[autocmd User MiniStarterOpened
@@ -374,6 +375,59 @@ Config: >
       show_integration_count = false,
     }
   })
+<
+
+# A fancier scrollbar (like pure scrollbar, but with signs) ~
+
+To achieve this, override the |MiniMap.encode_strings()| function to
+produce placeholder symbols of our choice. Then set both their background
+and foreground to the color of your scrollbar background. This way, the
+symbols column will be invisible when no signs are present.
+
+Config: >
+
+  local mini_map = require('mini.map')
+  mini_map.setup({
+    symbols = {
+      -- indicators: --  -- ▶ -- ▸ -- ◆ -- ► --
+      scroll_line = '►',
+      -- left aligned: -- ▏-- ▎ -- ▍ -- ▌ -- ▋ -- ▊ -- ▉ -- █ --
+      -- centered: -- │ -- ┃ --
+      scroll_view = '▋',
+    },
+    window = {
+      -- set to true if you want to see count, also set width = 3
+      show_integration_count = false,
+      width = 2,
+      winblend = 0,
+    },
+    integrations = {
+      mini_map.gen_integration.builtin_search({ search = 'MyMiniMapSearch' }),
+      mini_map.gen_integration.diagnostic({
+        error = 'DiagnosticError',
+        warn = 'DiagnosticWarn',
+      }),
+      mini_map.gen_integration.gitsigns({
+        add = 'DiffAdd',
+        change = 'DiffChange',
+        delete = 'DiffDelete',
+      }),
+    },
+  })
+
+  ---@diagnostic disable-next-line: duplicate-set-field
+  mini_map.encode_strings = function(strings)
+    local res = {}
+    local placeholder = '▐' -- right-aligned: -- ▕ -- ▐ --
+    for _ = 1, #strings do
+      table.insert(res, placeholder)
+    end
+    return res
+  end
+
+  -- replace 'black' with your background color for the scrollbar
+  vim.api.nvim_set_hl(0, 'MiniMapNormal', { fg = 'black', bg = 'black' })
+<
 
 ------------------------------------------------------------------------------
                                                                *MiniMap.current*

--- a/lua/mini/map.lua
+++ b/lua/mini/map.lua
@@ -57,7 +57,8 @@
 ---   |MiniMap.toggle_side()|. Works best with global statusline.
 --- - Provide autoopen functionality. Due to vast differences in user preference
 ---   of when map window should be shown, set up of automatic opening is left to
----   user. A common approach would be to call `MiniMap.open()` on |VimEnter| event.
+---   user. A common approach would be to call `MiniMap.open()` on |VimEnter| or
+---   |UIEnter| event.
 ---   If you use |MiniStarter|, you can modify `<CR>` buffer mapping: >
 ---
 ---   vim.cmd([[autocmd User MiniStarterOpened
@@ -357,6 +358,59 @@ end
 ---       show_integration_count = false,
 ---     }
 ---   })
+--- <
+---
+--- # A fancier scrollbar (like pure scrollbar, but with signs) ~
+---
+--- To achieve this, override the |MiniMap.encode_strings()| function to
+--- produce placeholder symbols of our choice. Then set both their background
+--- and foreground to the color of your scrollbar background. This way, the
+--- symbols column will be invisible when no signs are present.
+---
+--- Config: >
+---
+---   local mini_map = require('mini.map')
+---   mini_map.setup({
+---     symbols = {
+---       -- indicators: --  -- ▶ -- ▸ -- ◆ -- ► --
+---       scroll_line = '►',
+---       -- left aligned: -- ▏-- ▎ -- ▍ -- ▌ -- ▋ -- ▊ -- ▉ -- █ --
+---       -- centered: -- │ -- ┃ --
+---       scroll_view = '▋',
+---     },
+---     window = {
+---       -- set to true if you want to see count, also set width = 3
+---       show_integration_count = false,
+---       width = 2,
+---       winblend = 0,
+---     },
+---     integrations = {
+---       mini_map.gen_integration.builtin_search({ search = 'MyMiniMapSearch' }),
+---       mini_map.gen_integration.diagnostic({
+---         error = 'DiagnosticError',
+---         warn = 'DiagnosticWarn',
+---       }),
+---       mini_map.gen_integration.gitsigns({
+---         add = 'DiffAdd',
+---         change = 'DiffChange',
+---         delete = 'DiffDelete',
+---       }),
+---     },
+---   })
+---
+---   ---@diagnostic disable-next-line: duplicate-set-field
+---   mini_map.encode_strings = function(strings)
+---     local res = {}
+---     local placeholder = '▐' -- right-aligned: -- ▕ -- ▐ --
+---     for _ = 1, #strings do
+---       table.insert(res, placeholder)
+---     end
+---     return res
+---   end
+---
+---   -- replace 'black' with your background color for the scrollbar
+---   vim.api.nvim_set_hl(0, 'MiniMapNormal', { fg = 'black', bg = 'black' })
+--- <
 MiniMap.config = {
   -- Highlight integrations (none by default)
   integrations = nil,


### PR DESCRIPTION
- [x ] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x ] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

First of all, thank you for this nice set of libraries! I really enjoy using them and also greatly appreciate your goal to keep the code minimal and maintainable. So many plugins today are too complex, resulting in weird bugs and bad performance. Yours are a pleasant exception. I am hoping they will stay that way :)

This PR adds a configuration example for `mini.map`, that makes it look like a "pure scrollbar", but with signs (see screenshot).
I consider it to be a common case, where someone may want a scrollbar (without the map), but with signs that show errors, git added / removed, search hits.

This config may seem a bit "creative", but IMHO it's better to use this, than adding another config option (and complexity).

Cheers!

P.S. regarding when to trigger `MiniMap.open()`: I have added `UIEnter` next to `VimEnter` event, since this one is that worked for me on windows with alacritty.

![minimap-scrollbar-fancy](https://github.com/echasnovski/mini.nvim/assets/7132507/aa246b15-653f-4b6a-ac9a-bba2ebf0bf0a)
