### PR TITLE
fix(diff): redraw statusline with nvim__redraw if available

### DIFF
--- a/lua/mini/diff.lua
+++ b/lua/mini/diff.lua
@@ -1206,9 +1206,6 @@ H.update_buf_diff = vim.schedule_wrap(function(buf_id)
   -- Force redraw. NOTE: Using 'redraw' not always works (`<Cmd>update<CR>`
   -- from keymap with "save" source will not redraw) while 'redraw!' flickers.
   H.redraw_buffer(buf_id)
-
-  -- Redraw statusline to have possible statusline component up to date
-  vim.cmd('redrawstatus')
 end)
 
 H.update_hunk_data = function(diff, buf_cache, buf_lines)
@@ -1737,9 +1734,14 @@ H.is_buf_text = function(buf_id)
 end
 
 -- nvim__redraw replaced nvim__buf_redraw_range during the 0.10 release cycle
-H.redraw_buffer = function(buf_id) vim.api.nvim__buf_redraw_range(buf_id, 0, -1) end
+H.redraw_buffer = function(buf_id)
+  vim.api.nvim__buf_redraw_range(buf_id, 0, -1)
+
+  -- Redraw statusline to have possible statusline component up to date
+  vim.cmd('redrawstatus')
+end
 if vim.api.nvim__redraw ~= nil then
-  H.redraw_buffer = function(buf_id) vim.api.nvim__redraw({ buf = buf_id, valid = true }) end
+  H.redraw_buffer = function(buf_id) vim.api.nvim__redraw({ buf = buf_id, valid = true, statusline = true }) end
 end
 
 return MiniDiff


### PR DESCRIPTION
Redrawing the statusline with :redrawstatus causes visible flicker when text changes are made rapidly (e.g. writing in Insert mode) and when the `delay.text_change` config option is set to a low value (e.g. 100). Instead, we can redraw the statusline at the same time that we redraw the buffer with nvim__redraw.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
