### PR TITLE
mini.surround: Added explanaition of defining output specification with function to documentation

### DIFF
--- a/lua/mini/surround.lua
+++ b/lua/mini/surround.lua
@@ -361,13 +361,18 @@
 ---
 --- # Output surrounding ~
 ---
---- A table with <left> (plain text string) and <right> (plain text string)
---- fields. Strings can contain new lines character `\n` to add multiline parts.
+--- Specification for output can be defined either as a table with <left> and <right> fields,
+--- or as a function that returns similar table. Strings can contain new lines character `\n` to add multiline parts.
 ---
 --- Examples:
 --- - Lua block string: `{ left = '[[', right = ']]' }`
 --- - Brackets on separate lines (indentation is not preserved):
 ---   `{ left = '(\n', right = '\n)' }`
+--- - Function call:
+--- function()
+---     local function_name = MiniSurround.user_input('Function name: ', 'foo')
+---     return { left = function_name .. '(', right = ')' }
+--- end
 ---@tag MiniSurround-surround-specification
 
 --- Count with actions


### PR DESCRIPTION
- [x ] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)

- [x ] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

When reading through docs of mini.surround, I noticed that they explain only one way of defining output specification of surround, with plain strings. Later in examples the docs show that we can also use functions that return output specification. 
So I wanted to add this option to surround specification. And I also added an example with output of a default function call surround.
