### PR TITLE
feat(base16): allow to only use cterm colors

### DIFF
--- a/doc/mini-base16.txt
+++ b/doc/mini-base16.txt
@@ -143,9 +143,9 @@ groups make an extended set from original
 good idea to have `config.palette` respect the original [styling
 principles](https://github.com/chriskempson/base16/blob/master/styling.md).
 
-By default only 'gui highlighting' (see |highlight-gui| and
-|termguicolors|) is supported. To support 'cterm highlighting' (see
-|highlight-cterm|) supply `config.use_cterm` argument in one of the formats:
+To support 'gui highlighting' (see |highlight-gui| and |termguicolors|), supply
+`config.palette`. To support 'cterm highlighting' (see |highlight-cterm|),
+supply `config.use_cterm` argument in one of the formats:
 - `true` to auto-generate from `palette` (as closest colors).
 - Table with similar structure to `palette` but having terminal colors
   (integers from 0 to 255) instead of hex strings.
@@ -155,7 +155,8 @@ Parameters ~
 
 Usage ~
 `require('mini.base16').setup({})` (replace `{}` with your `config`
-  table; `config.palette` should be a table with colors)
+  table; either or both of `config.palette` and `config.use_term` should be a
+  table with colors)
 
 ------------------------------------------------------------------------------
                                                              *MiniBase16.config*
@@ -167,12 +168,13 @@ Default values:
   MiniBase16.config = {
     -- Table with names from `base00` to `base0F` and values being strings of
     -- HEX colors with format "#RRGGBB". NOTE: this should be explicitly
-    -- supplied in `setup()`.
+    -- supplied in `setup()` if `config.use_cterm` is not supplied as a table.
     palette = nil,
 
     -- Whether to support cterm colors. Can be boolean, `nil` (same as
     -- `false`), or table with cterm colors. See `setup()` documentation for
-    -- more information.
+    -- more information. NOTE: this should be explicitly supplied in `setup()` as a
+    -- table with cterm colors if `config.palette` is not supplied.
     use_cterm = nil,
 
     -- Plugin integrations. Use `default = false` to disable all integrations.

--- a/readmes/mini-base16.md
+++ b/readmes/mini-base16.md
@@ -179,12 +179,13 @@ Here are code snippets for some common installation methods (use only one):
 {
   -- Table with names from `base00` to `base0F` and values being strings of
   -- HEX colors with format "#RRGGBB". NOTE: this should be explicitly
-  -- supplied in `setup()`.
+  -- supplied in `setup()` if `config.use_cterm` is not supplied as a table.
   palette = nil,
 
   -- Whether to support cterm colors. Can be boolean, `nil` (same as
   -- `false`), or table with cterm colors. See `setup()` documentation for
-  -- more information.
+  -- more information. NOTE: this should be explicitly supplied in `setup()` as a
+  -- table with cterm colors if `config.palette` is not supplied.
   use_cterm = nil,
 
   -- Plugin integrations. Use `default = false` to disable all integrations.

--- a/tests/test_base16.lua
+++ b/tests/test_base16.lua
@@ -104,6 +104,7 @@ T['setup()']['validates `config` argument'] = function()
   end
 
   expect_config_error('a', 'config', 'table')
+  expect_config_error({ use_cterm = true }, 'config.use_cterm', 'table')
   expect_config_error({ palette = 'a' }, 'config.palette', 'table')
   expect_config_error({ palette = { 'a' } }, 'config.palette', 'base00')
   expect_config_error({ palette = { base00 = 1 } }, 'config.palette', 'HEX')
@@ -155,6 +156,12 @@ T['setup()']['respects `config.use_cterm`'] = function()
   )
 
   reload_module({ palette = minischeme_palette, use_cterm = p_cterm })
+  validate_hl_group(
+    'Normal',
+    ('ctermfg=%s ctermbg=%s guifg=%s guibg=%s'):format(p_cterm.base05, p_cterm.base00, p.base05, p.base00)
+  )
+
+  reload_module({ use_cterm = p_cterm })
   validate_hl_group(
     'Normal',
     ('ctermfg=%s ctermbg=%s guifg=%s guibg=%s'):format(p_cterm.base05, p_cterm.base00, p.base05, p.base00)


### PR DESCRIPTION
Make `config.palette` optional if `config.use_cterm` is provided as a table with cterm colors.

Resolve #456

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
