### PR TITLE
docs(mini.test): adding note about lua-language-server related config 

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -136,6 +136,7 @@ Overview of full file structure used in for testing 'hello_lines' plugin:
 │   └── hello_lines
 │       └── init.lua # Mandatory
 ├── Makefile # Recommended
+├── .luarc.json # Recommended
 ├── scripts
 │   ├── minimal_init.lua # Mandatory
 │   └── minitest.lua # Recommended
@@ -212,6 +213,20 @@ test_file: deps/mini.nvim
 deps/mini.nvim:
 	@mkdir -p deps
 	git clone --filter=blob:none https://github.com/echasnovski/mini.nvim $@
+```
+
+</details><br>
+
+- **.luarc.json**. If you would like to get completions for mini.test in your editor from `lua-language-server`, it is recommended to set up a `.luarc.json` file that knows about `deps/` and to explicitly require `mini.test` in your test files (ex: `local MiniTest = require('mini.test')`)
+
+<details><summary>Template for '.luarc.json'</summary>
+
+```
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "runtime.version": "LuaJIT",
+  "workspace.library": ["./lua", "deps/mini.nvim/lua"]
+}
 ```
 
 </details><br>


### PR DESCRIPTION
- [ x ] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [ x ] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Spent like a couple of hours getting completion working for MiniTest and I figured I would add a note to the docs since it greatly helps with discoverability of the api:

here's a screenshot of it in action:
<img width="1152" alt="image" src="https://github.com/echasnovski/mini.nvim/assets/95201/d6fb0c04-6573-44c7-85b7-8621732cc4e4">
