### PR TITLE
feat(deps): react to `vim.loop.cpu_info` returning `nil`

### DIFF
--- a/lua/mini/deps.lua
+++ b/lua/mini/deps.lua
@@ -1459,7 +1459,12 @@ end
 -- CLI ------------------------------------------------------------------------
 H.cli_run = function(jobs)
   local config_job = H.get_config().job
-  local n_threads = config_job.n_threads or math.floor(0.8 * #vim.loop.cpu_info())
+  local n_threads = config_job.n_threads
+  if not n_threads then
+    local cpus = vim.loop.cpu_info()
+    local n_cpus = (type(cpus) == 'table') and #cpus or 1
+    n_threads = math.floor(0.8 * n_cpus)
+  end
   local timeout = config_job.timeout or 30000
 
   -- Use only actually runnable jobs


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

## Problem
When running Neovim in a [Termux](https://termux.dev/en/) environment, the `vim.loop.cpu_info` function is returning `nil`.  
Hence, running `DepsUpdate` fails with a `attempt to get length of a nil value` message.

## Solution
Ensure that `vim.loop.cpu_info()` is returning a table before getting its length: if not a table, use `1` as a fallback value of number of processors.