### PR TITLE
refactor(completion): remove deprecated `vim.lsp.util.trim_empty_lines`

### DIFF
--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -909,7 +909,7 @@ H.show_info_window = function()
     lines = H.process_lsp_response(H.info.lsp.result, function(response)
       if not response.documentation then return {} end
       local res = vim.lsp.util.convert_input_to_markdown_lines(response.documentation)
-      return vim.lsp.util.trim_empty_lines(res)
+      return vim.split(table.concat(res, '\n'), '\n', { trimempty = true })
     end)
 
     H.info.lsp.status = 'done'
@@ -966,7 +966,7 @@ H.info_window_lines = function(info_id)
   local doc = lsp_completion_item.documentation
   if doc then
     local lines = vim.lsp.util.convert_input_to_markdown_lines(doc)
-    return vim.lsp.util.trim_empty_lines(lines)
+    return vim.split(table.concat(lines, '\n'), '\n', { trimempty = true })
   end
 
   -- Finally, try request to resolve current completion to add documentation

--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -909,7 +909,7 @@ H.show_info_window = function()
     lines = H.process_lsp_response(H.info.lsp.result, function(response)
       if not response.documentation then return {} end
       local res = vim.lsp.util.convert_input_to_markdown_lines(response.documentation)
-      return vim.split(table.concat(res, '\n'), '\n', { trimempty = true })
+      return H.trim_empty_lines(res)
     end)
 
     H.info.lsp.status = 'done'
@@ -966,7 +966,7 @@ H.info_window_lines = function(info_id)
   local doc = lsp_completion_item.documentation
   if doc then
     local lines = vim.lsp.util.convert_input_to_markdown_lines(doc)
-    return vim.split(table.concat(lines, '\n'), '\n', { trimempty = true })
+    return H.trim_empty_lines(lines)
   end
 
   -- Finally, try request to resolve current completion to add documentation
@@ -1391,5 +1391,13 @@ H.islist = vim.fn.has('nvim-0.10') == 1 and vim.islist or vim.tbl_islist
 
 H.get_buf_lsp_clients = function() return vim.lsp.get_clients({ bufnr = 0 }) end
 if vim.fn.has('nvim-0.10') == 0 then H.get_buf_lsp_clients = function() return vim.lsp.buf_get_clients() end end
+
+H.trim_empty_lines = function(lines)
+  if vim.fn.has('nvim-0.10') then
+    return vim.split(table.concat(lines, '\n'), '\n', { trimempty = true })
+  else
+    return vim.lsp.util.trim_empty_lines(lines)
+  end
+end
 
 return MiniCompletion


### PR DESCRIPTION
`vim.lsp.util.trim_empty_lines` is considered deprecated with the release of nvim v0.10.0. Instances of this function have been replaced with `vim.split(...)` with `trimempty = true` following the neovim repo.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

### Module(s)
Completion

### Description
With the release of Neovim v0.10.0, `vim.lsp.util.trim_empty_lines` was deprecated in favor of using `vim.split` with the `trimempty` flag set. I was getting deprecated popups while using `mini.completion`, so I put in this quick refactor.
