### PR TITLE
fix(statusline)!: make compute_attached_lsp() depend only number of attached client

### DIFF
--- a/lua/mini/statusline.lua
+++ b/lua/mini/statusline.lua
@@ -631,8 +631,8 @@ if vim.fn.has('nvim-0.8') == 0 then
 end
 
 H.compute_attached_lsp = function(buf_id)
-  local names = vim.tbl_map(function() return '+' end, H.get_buf_lsp_clients(buf_id))
-  return table.concat(names, '')
+  local count = vim.tbl_count(H.get_buf_lsp_clients(buf_id))
+  return string.rep('+', count)
 end
 
 H.get_buf_lsp_clients = function(buf_id) return vim.lsp.get_clients({ bufnr = buf_id }) end


### PR DESCRIPTION


`H.get_buf_lsp_clients` will return a map of `client_id:client`. So if we handle it as array, there could be hole in it, and `table.concat` will fail with "invalid value (nil) at index [i] in table for 'concat'".

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
