### PR TITLE
fix(files): make `window_focus` setup correct win_id for current buffer

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -2218,6 +2218,8 @@ end
 
 H.window_focus = function(win_id)
   vim.api.nvim_set_current_win(win_id)
+  local has_buffer, buf_id = pcall(vim.api.nvim_win_get_buf, win_id)
+  if has_buffer and H.opened_buffers[buf_id] ~= nil then H.opened_buffers[buf_id].win_id = win_id end
   H.window_update_highlight(win_id, 'FloatTitle', 'MiniFilesTitleFocused')
 end
 


### PR DESCRIPTION
When setup `config.windows.preview = true`, and go in to directory depth that make maximum number of window width exceeds nvim width, the preview window will not refresh when `CursorMoved` triggered.

Here's a show case:
![mini files-bug](https://github.com/echasnovski/mini.nvim/assets/30885216/e5606667-b9fa-4747-93a1-36b77fec8103)

After some dig I find out that in this case, when
`H.explorer_refresh_depth_window` and `H.window_close` called in `H.explorer_refresh`, the buffer on current window will lost their `win_id`.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
