### PR TITLE
docs(surround): small typo

### DIFF
--- a/doc/mini-surround.txt
+++ b/doc/mini-surround.txt
@@ -84,7 +84,7 @@ Extended mappings (temporary force "prev"/"next" search methods):
 - `sdnf` - delete (`sd`) next (`n`) function call (`f`).
 - `srlf(` - replace (`sr`) last (`l`) function call (`f`) with padded
   bracket (`(`).
-- `2sfnt` - find (`sf`) second (2) next (`n`) tag (`t`).
+- `2sfnt` - find (`sf`) second (`2`) next (`n`) tag (`t`).
 - `2shl}` - highlight (`sh`) last (`l`) second (`2`) curly bracket (`}`).
 
 # Comparisons ~


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
