### PR TITLE
feat(extra): add flag 'current_dir' to `oldfiles()` picker

### DIFF
--- a/doc/mini-extra.txt
+++ b/doc/mini-extra.txt
@@ -640,7 +640,9 @@ Pick from |v:oldfiles| entries representing readable files.
 
 Parameters ~
 {local_opts} `(table|nil)` Options defining behavior of this particular picker.
-  Not used at the moment.
+  Possible fields:
+  - <current_dir> `(boolean|nil)` - whether to return files only from
+    current working directory and its subdirectories. Default: `false`.
 {opts} `(table|nil)` Options forwarded to |MiniPick.start()|.
 
 Return ~

--- a/tests/test_extra.lua
+++ b/tests/test_extra.lua
@@ -2684,6 +2684,18 @@ T['pickers']['oldfiles()']['respects `opts.source.cwd`'] = function()
   expect.match(items[2], vim.pesc(child.fn.fnamemodify(ref_oldfiles[2], ':~')))
 end
 
+T['pickers']['oldfiles()']['respects `local_opts.current_dir'] = function()
+  child.set_size(10, 70)
+  local ref_oldfiles = { full_path(real_file('LICENSE')), full_path(make_testpath('mocks', 'diagnostic.lua')) }
+  child.v.oldfiles = ref_oldfiles
+
+  pick_oldfiles({ current_dir = true }, { source = { cwd = real_files_dir } })
+  local items = get_picker_items()
+  -- - Only paths inside `cwd` are shown
+  eq(#items, 1)
+  eq(items[1], 'LICENSE')
+end
+
 T['pickers']['options()'] = new_set()
 
 local pick_options = forward_lua_notify('MiniExtra.pickers.options')


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Reference: This [discussion](https://github.com/echasnovski/mini.nvim/discussions/995)

In my workflow, each project is opened in a `tmux` session. As such, when querying `oldfiles`, I am mostly interested in files inside the current working directory.

`MiniExtra.pickers.oldfiles()` currently does not filter on `cwd`

This PR adds flag "current_dir" to `MiniExtra.pickers.oldfiles()`