### PR TITLE
fix(hipatterns): compute_hex_color_group: cache per style and set default style

### DIFF
--- a/lua/mini/hipatterns.lua
+++ b/lua/mini/hipatterns.lua
@@ -622,7 +622,7 @@ end
 ---   |:colorscheme| command to clear cache. Needs a call to |MiniHipatterns.setup()|.
 ---
 ---@param hex_color string Hex color string in format `#rrggbb`.
----@param style string One of:
+---@param style? string One of:
 ---   - `'bg'` - highlight background with `hex_color` and foreground with black or
 ---     white (whichever is more visible). Default.
 ---   - `'fg'` - highlight foreground with `hex_color`.
@@ -630,8 +630,9 @@ end
 ---
 ---@return string Name of created highlight group appropriate to show `hex_color`.
 MiniHipatterns.compute_hex_color_group = function(hex_color, style)
+  style = style or 'bg'
   local hex = hex_color:lower():sub(2)
-  local group_name = 'MiniHipatterns' .. hex
+  local group_name = 'MiniHipatterns' .. hex .. style
 
   -- Use manually tracked table instead of `vim.fn.hlexists()` because the
   -- latter still returns true for cleared highlights


### PR DESCRIPTION
Hi!

Two minor fixes for `compute_hex_color_group`:

- The docs mention that `style='bg'` is the default, but the code does not work without a default
- When using the same colors with multiple styles (different highlighters even), it doesn't use the correct style.

Having a lot of fun with hipatterns for developing tokyonight :)

![image](https://github.com/echasnovski/mini.nvim/assets/292349/966551f1-508e-4376-ae1f-82aaeabd19d6)
