### PR TITLE
feat(icons): support for bicep filetype and extensions

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -560,6 +560,7 @@ H.extension_icons = {
   -- Value is string with filetype's name to inherit from its icon data
   asm   = 'asm',
   bib   = 'bib',
+  bicepparam = 'bicepparam',
   bzl   = 'bzl',
   c     = 'c',
   cbl   = 'cobol',
@@ -812,6 +813,8 @@ H.filetype_icons = {
   bc                 = { glyph = '󰫯', hl = 'MiniIconsCyan'   },
   bdf                = { glyph = '󰛖', hl = 'MiniIconsRed'    },
   bib                = { glyph = '󱉟', hl = 'MiniIconsYellow' },
+  bicep              = { glyph = '', hl = 'MiniIconsCyan'   },
+  bicepparam         = { glyph = '', hl = 'MiniIconsPurple' },
   bindzone           = { glyph = '󰫯', hl = 'MiniIconsCyan'   },
   bitbake            = { glyph = '󰃫', hl = 'MiniIconsOrange' },
   blank              = { glyph = '󰫯', hl = 'MiniIconsPurple' },


### PR DESCRIPTION
This PR brings support for bicep/bicepparam files to mini.icons. This is fairly close to how these icons look in vscode:
![image](https://github.com/echasnovski/mini.nvim/assets/39483124/e4541168-daaa-4b1b-b052-58027d15e59c)

I'm very aware that I've probably messed up the formatting in the extension icons table. I'm hoping someone with mini align configured can fix it the next time this file is edited 😉 

See also: [my PR for this in nvim-webdev-icons.](https://github.com/nvim-tree/nvim-web-devicons/pull/461)

