### PR TITLE
feat(icons): add more os icons

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -1618,6 +1618,7 @@ H.lsp_icons = {
 -- this feels representative of "popular" operating systems.
 --stylua: ignore
 H.os_icons = {
+  alpine       = { glyph = '', hl = 'MiniIconsBlue'   },
   android      = { glyph = '󰀲', hl = 'MiniIconsGreen'  },
   arch         = { glyph = '󰣇', hl = 'MiniIconsAzure'  },
   centos       = { glyph = '󱄚', hl = 'MiniIconsRed'    },
@@ -1631,9 +1632,11 @@ H.os_icons = {
   manjaro      = { glyph = '󱘊', hl = 'MiniIconsGreen'  },
   mint         = { glyph = '󰣭', hl = 'MiniIconsGreen'  },
   nixos        = { glyph = '󱄅', hl = 'MiniIconsAzure'  },
+  pop_os       = { glyph = '', hl = 'MiniIconsBlue'   },
   raspberry_pi = { glyph = '󰐿', hl = 'MiniIconsRed'    },
   redhat       = { glyph = '󱄛', hl = 'MiniIconsRed'    },
   ubuntu       = { glyph = '󰕈', hl = 'MiniIconsOrange' },
+  void         = { glyph = '', hl = 'MiniIconsGreen'  },
   windows      = { glyph = '󰖳', hl = 'MiniIconsBlue'   },
 }
 


### PR DESCRIPTION
Not sure if these icons can be accepted since they are found in the `nf-linux-*` class, but they're arguably popular linux distros so I decided to take my shot :)

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)