### PR TITLE
fix(icons): ensure highlights are setup when changing colorschemes

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -1674,6 +1674,14 @@ H.apply_config = function(config)
   H.init_cache(config)
 end
 
+H.create_autocommands = function()
+  local augroup = vim.api.nvim_create_augroup('MiniIcons', {})
+  vim.api.nvim_create_autocmd(
+    'ColorScheme',
+    { group = augroup, callback = H.create_default_hl, desc = 'Ensure proper colors' }
+  )
+end
+
 --stylua: ignore
 H.create_default_hl = function()
   local hi = function(name, opts)


### PR DESCRIPTION
This adds an autocommand on the `ColorScheme` event to make sure highlights are created if necessary for `mini.icons`

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
