### PR TITLE
feat(icons): add `mock_lspkind` to emulate `lspkind.nvim`

### DIFF
--- a/doc/mini-icons.txt
+++ b/doc/mini-icons.txt
@@ -23,6 +23,9 @@ Features:
 - Mocking methods of 'nvim-tree/nvim-web-devicons' for better integrations
   with plugins outside 'mini.nvim'. See |MiniIcons.mock_nvim_web_devicons()|.
 
+- Mocking methods of 'onsails/lspkind.nvim' for better integrations
+  with plugins outside 'mini.nvim'. See |MiniIcons.mock_lspkind()|.
+
 Notes:
 
 - It is not a goal to become a collection of icons for as much use cases as
@@ -418,6 +421,26 @@ Full example of usage: >lua
 <
 Works without installed 'nvim-web-devicons' and even with it installed (needs
 to be called after 'nvim-web-devicons' is set up).
+
+------------------------------------------------------------------------------
+                                                      *MiniIcons.mock_lspkind()*
+                           `MiniIcons.mock_lspkind`()
+Mock 'lspkind' module
+
+Call this function to mock exported functions of 'onsails/lspkind.nvim'
+plugin. It will mock all its functions which return icon data by
+using |MiniIcons.get()| equivalent.
+
+This function is useful until all relevant to you plugins depend solely on
+'lspkind' and have not yet added an integration with 'mini.icons'.
+
+Full example of usage: >lua
+
+  require('mini.icons').setup()
+  MiniIcons.mock_lspkind()
+<
+Works without installed 'lspkind' and even with it installed (needs
+to be called after 'lspkind' is set up).
 
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -595,7 +595,7 @@ MiniIcons.mock_lspkind = function()
 
   M.symbolic = function(kind, opts)
     local mode = opts and opts.mode or 'symbol'
-    local symbol, _ = MiniIcons.get('lsp', kind)
+    local symbol = MiniIcons.get('lsp', kind)
     if mode == 'text' then
       symbol = kind
     elseif mode == 'text_symbol' then
@@ -613,16 +613,14 @@ MiniIcons.mock_lspkind = function()
 
       vim_item.kind = M.symbolic(vim_item.kind, opts)
 
-      if opts.menu ~= nil then
-        vim_item.menu = (opts.menu[entry.source.name] ~= nil and opts.menu[entry.source.name] or '')
-          .. ((opts.show_labelDetails and vim_item.menu ~= nil) and vim_item.menu or '')
+      if opts.menu then
+        vim_item.menu = (opts.menu[entry.source.name] or '') .. (opts.show_labelDetails and vim_item.menu or '')
       end
 
-      if opts.maxwidth ~= nil then
+      if opts.maxwidth then
         local maxwidth = type(opts.maxwidth) == 'function' and opts.maxwidth() or opts.maxwidth
         if vim.fn.strchars(vim_item.abbr) > maxwidth then
-          vim_item.abbr = vim.fn.strcharpart(vim_item.abbr, 0, maxwidth)
-            .. (opts.ellipsis_char ~= nil and opts.ellipsis_char or '')
+          vim_item.abbr = vim.fn.strcharpart(vim_item.abbr, 0, maxwidth) .. (opts.ellipsis_char or '')
         end
       end
       return vim_item

--- a/readmes/mini-icons.md
+++ b/readmes/mini-icons.md
@@ -40,6 +40,8 @@ If you want to help this project grow but don't know where to start, check out [
 
 - Mocking methods of 'nvim-tree/nvim-web-devicons' for better integrations with plugins outside 'mini.nvim'. See `:h MiniIcons.mock_nvim_web_devicons()`.
 
+- Mocking methods of 'onsails/lspkind.nvim' for better integrations with plugins outside 'mini.nvim'. See `:h MiniIcons.mock_lspkind()`.
+
 Notes:
 
 - It is not a goal to become a collection of icons for as much use cases as possible. There are specific criteria for icon data to be included as built-in in each category (see `:h MiniIcons.get()`). The main supported category is "filetype".
@@ -178,3 +180,4 @@ Here are code snippets for some common installation methods (use only one):
 ## Similar plugins
 
 - [nvim-tree/nvim-web-devicons](https://github.com/nvim-tree/nvim-web-devicons)
+- [onsails/lspkind.nvim](https://github.com/onsails/lspkind.nvim)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

This takes a stab at adding `lspkind` emulation to `mini.icons` to help integrate it with more plugins. There are only 2 API functions which make it a really nice candidate for emulation. This also adds some tests to make sure that the 2 functions work. Let me know what you think or if you have any recommendations to improve this.


Thanks for such a great icons module 🥳 