### PR TITLE
feat(icons): icons for heic and dng filetypes

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -751,6 +751,8 @@ H.extension_icons = {
   tif  = { glyph = '󰈟', hl = 'MiniIconsYellow' },
   tiff = { glyph = '󰈟', hl = 'MiniIconsYellow' },
   webp = { glyph = '󰈟', hl = 'MiniIconsBlue'   },
+  heic = { glyph = '󰺰', hl = 'MiniIconsYellowc' },
+  dng  = { glyph = '󰺰', hl = 'MiniIconsPurple' },
 
   -- Archives
   ["7z"] = { glyph = '󰗄', hl = 'MiniIconsBlue'   },

--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -751,7 +751,7 @@ H.extension_icons = {
   tif  = { glyph = '󰈟', hl = 'MiniIconsYellow' },
   tiff = { glyph = '󰈟', hl = 'MiniIconsYellow' },
   webp = { glyph = '󰈟', hl = 'MiniIconsBlue'   },
-  heic = { glyph = '󰺰', hl = 'MiniIconsYellowc' },
+  heic = { glyph = '󰺰', hl = 'MiniIconsYellow' },
   dng  = { glyph = '󰺰', hl = 'MiniIconsPurple' },
 
   -- Archives


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md) file.
- [x] I have read the [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md) file.

Usually, iPhones have `dng` and `heic` filetypes for images. This PR adds icon support for those as well.
