### PR TITLE
feat(icons): add `gitlab-ci.yml`

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -800,6 +800,7 @@ H.file_icons = {
   ['.DS_Store']          = { glyph = '󰒓', hl = 'MiniIconsRed'    },
   ['.bash_profile']      = { glyph = '󰒓', hl = 'MiniIconsGreen'  },
   ['.bashrc']            = { glyph = '󰒓', hl = 'MiniIconsGreen'  },
+  ['.gitlab-ci.yml']     = { glyph = "󰮠", hl = "MiniIconsOrange" },
   ['.git']               = { glyph = '󰊢', hl = 'MiniIconsOrange' },
   ['.gitkeep']           = { glyph = '󰊢', hl = 'MiniIconsRed'    },
   ['.mailmap']           = { glyph = '󰊢', hl = 'MiniIconsCyan'   },


### PR DESCRIPTION
Because `gitlab-ci.yml` is a specific file used on gitlab for CI/CD stuff, i think should be cool to assume as mandatory in this libs =) 

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
