### PR TITLE
fix(hues): Leap deprecated highlights, use LeapLabel

### DIFF
--- a/lua/mini/hues.lua
+++ b/lua/mini/hues.lua
@@ -1254,8 +1254,7 @@ H.apply_colorscheme = function(config)
 
   if has_integration('ggandor/leap.nvim') then
     hi('LeapMatch',          { fg=p.green,  bg=nil, bold=true, nocombine=true, underline=true })
-    hi('LeapLabelPrimary',   { fg=p.yellow, bg=nil, bold=true, nocombine=true })
-    hi('LeapLabelSecondary', { fg=p.fg,     bg=nil, bold=true, nocombine=true })
+    hi('LeapLabel',          { fg=p.yellow, bg=nil, bold=true, nocombine=true })
     hi('LeapLabelSelected',  { fg=p.cyan,   bg=nil, bold=true, nocombine=true })
     hi('LeapBackdrop',       { link='Comment' })
   end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

LeapLabelPrimary and LeapLabelSecondary are deprecated, see [b75a86f](https://github.com/ggandor/leap.nvim/commit/b75a86f14ebdb3940460bfd1a02224210eccc698)

If this PR is according to expectations I would like to provide a PR for mini.base16.

Screenshots, typing `sif` on line 1:

Before:

![1720683649](https://github.com/echasnovski/mini.nvim/assets/58370433/301f0823-eea8-4d9d-b296-4a64004ff8b5)

After:

![1720683692](https://github.com/echasnovski/mini.nvim/assets/58370433/dc21eb6f-5df5-43da-922e-9acc8dee3444)
