### PR TITLE
feat(icons): add `hcl` filetype

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -1115,6 +1115,7 @@ H.filetype_icons = {
   haste              = { glyph = '󰫵', hl = 'MiniIconsYellow' },
   hastepreproc       = { glyph = '󰫵', hl = 'MiniIconsCyan'   },
   hb                 = { glyph = '󰫵', hl = 'MiniIconsGreen'  },
+  hcl                = { glyph = '󰫵', hl = 'MiniIconsAzure'  },
   heex               = { glyph = '', hl = 'MiniIconsPurple' },
   help               = { glyph = '󰋖', hl = 'MiniIconsPurple' },
   hercules           = { glyph = '󰫵', hl = 'MiniIconsRed'    },


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

I noticed the HCL filetype is missing. This is a filetype that matches with `vim.filetype.match`. I also made sure to follow the guidelines when selecting an icon. Let me know what you think 😄 