### PR TITLE
fix(base16): leap deprecated highlights, use LeapLabel

### DIFF
--- a/lua/mini/base16.lua
+++ b/lua/mini/base16.lua
@@ -878,8 +878,7 @@ H.apply_palette = function(palette, use_cterm)
 
   if H.has_integration('ggandor/leap.nvim') then
     hi('LeapMatch',          {fg=p.base0E, bg=nil, attr='bold,nocombine,underline', sp=nil})
-    hi('LeapLabelPrimary',   {fg=p.base08, bg=nil, attr='bold,nocombine',           sp=nil})
-    hi('LeapLabelSecondary', {fg=p.base05, bg=nil, attr='bold,nocombine',           sp=nil})
+    hi('LeapLabel',          {fg=p.base08, bg=nil, attr='bold,nocombine',           sp=nil})
     hi('LeapLabelSelected',  {fg=p.base09, bg=nil, attr='bold,nocombine',           sp=nil})
     hi('LeapBackdrop',       {link='Comment'})
   end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

`LeapLabelPrimary` and `LeapLabelSecondary` are deprecated, see [b75a86f](https://github.com/ggandor/leap.nvim/commit/b75a86f14ebdb3940460bfd1a02224210eccc698)

Screenshots, typing `sif` on line 1:

Before:

![1720683791](https://github.com/echasnovski/mini.nvim/assets/58370433/01f5d197-54c8-4551-aa64-e9efd9c4e26b)

After:

![1720683825](https://github.com/echasnovski/mini.nvim/assets/58370433/2e08e3e2-0794-487f-b0a2-a3c336c47a12)
