### PR TITLE
feat(hues): allow 'palette' to be provided in config

### DIFF
--- a/doc/mini-hues.txt
+++ b/doc/mini-hues.txt
@@ -143,7 +143,8 @@ settings affect output color scheme.
 Default values:
 >lua
   MiniHues.config = {
-    -- **Required** base colors as '#rrggbb' hex strings
+    -- Base colors as '#rrggbb' hex strings. **Required** unless palette is
+    -- provided.
     background = nil,
     foreground = nil,
 
@@ -156,6 +157,10 @@ Default values:
     -- Accent color. One of: 'bg', 'fg', 'red', 'orange', 'yellow', 'green',
     -- 'cyan', 'azure', 'blue', 'purple'
     accent = 'bg',
+
+    -- Color palette table. Should match |MiniHues.make_palette()| return format.
+    -- If defined, takes precedence over background/foreground.
+    palette = nil,
 
     -- Plugin integrations. Use `default = false` to disable all integrations.
     -- Also can be set per plugin (see |MiniHues.config|).


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

## Problem

There is no way to tweak part of the palette, to adjust the whole colorscheme in consequence.  
For instance, if `red`component is not "red enough", user cannot fix it easily.

## Proposal

Add a `palette` key to the configuration, whose content matches what `MiniHues.make_palette` produces.  
If present, the `palette` content takes precedence over the rest of the configuration: `MiniHues.setup` won't internally use `MiniHues.make_palette`.

## Example

```lua
local palette = MiniHues.make_palette({ ... })    -- Create the palette with a "regular" config
palette.red = '#ff0000'                           -- Tweak the 'red' color to be completely red
MiniHues.setup({ palette = palette })             -- Apply colorschem, based on the modified palette
```

(_NB: This example is very simple, but finer adjustments could be done, involving `mini.colors` :smile:_)
