### PR TITLE
feat(icons): add gleam filetype icon

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -1087,7 +1087,7 @@ H.filetype_icons = {
   gitrebase          = { glyph = '󰊢', hl = 'MiniIconsAzure'  },
   gitsendemail       = { glyph = '󰊢', hl = 'MiniIconsBlue'   },
   gkrellmrc          = { glyph = '󰒓', hl = 'MiniIconsRed'    },
-  gleam              = { glyph = '', hl = 'MiniIconsPurple' },
+  gleam              = { glyph = '󰦥', hl = 'MiniIconsPurple' },
   gnash              = { glyph = '󰒓', hl = 'MiniIconsGreen'  },
   gnuplot            = { glyph = '󰺒', hl = 'MiniIconsPurple' },
   go                 = { glyph = '󰟓', hl = 'MiniIconsAzure'  },

--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -1087,6 +1087,7 @@ H.filetype_icons = {
   gitrebase          = { glyph = '󰊢', hl = 'MiniIconsAzure'  },
   gitsendemail       = { glyph = '󰊢', hl = 'MiniIconsBlue'   },
   gkrellmrc          = { glyph = '󰒓', hl = 'MiniIconsRed'    },
+  gleam              = { glyph = '', hl = 'MiniIconsPurple' },
   gnash              = { glyph = '󰒓', hl = 'MiniIconsGreen'  },
   gnuplot            = { glyph = '󰺒', hl = 'MiniIconsPurple' },
   go                 = { glyph = '󰟓', hl = 'MiniIconsAzure'  },


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

[Gleam](https://gleam.run/) is a new functional language that runs on Erlang and Javascript targets and I feel like it deserves an icon here for the `gleam` filetype. In the commit i used `nf-fa-star` because I think it looks more authentic to the actual [Gleam logo](https://avatars0.githubusercontent.com/u/36161205?s=400&v=4). If it really has to be from the `nf-md` I'll gladly change it, but I feel like the Font Awesome icon is more like the real logo.

**Example of it in Oil**
![example in oil](https://github.com/user-attachments/assets/31fdf5b0-9a38-4ec8-8857-a71b81605016)