### PR TITLE
docs(TESTING.md): fix typo in example

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -254,7 +254,7 @@ local T = MiniTest.new_set()
 
 T['works'] = function()
   local x = 1 + 1
-  MiniTest.expect(x, 2)
+  MiniTest.expect.equality(x, 2)
 end
 
 return T


### PR DESCRIPTION
I've really enjoyed your plugins. I have previously been using Plenary's testing harness but I'm starting to play with `mini.test` and noticed a typo in the example as I was going through things. `mini.test` looks really nice so far!

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)