### PR TITLE
fix(move): correctly restore registers, avoid error when buffer is empty

### DIFF
--- a/lua/mini/move.lua
+++ b/lua/mini/move.lua
@@ -221,8 +221,10 @@ MiniMove.move_selection = function(direction, opts)
   local cache_virtualedit = vim.o.virtualedit
   if not cache_virtualedit:find('all') then vim.o.virtualedit = 'onemore' end
 
-  -- Cut selection while saving caching register
-  local cache_z_reg = vim.fn.getreg('z')
+  -- Save original state of z register
+  local cache_z_reg = vim.fn.getreginfo('z')
+
+  -- Cut into z register
   cmd('"zx')
 
   -- Detect edge selection: last line(s) for vertical and last character(s)
@@ -340,8 +342,10 @@ MiniMove.move_line = function(direction, opts)
     return
   end
 
-  -- Cut curre lint while saving caching register
-  local cache_z_reg = vim.fn.getreg('z')
+  -- Save original state of z register
+  local cache_z_reg = vim.fn.getreginfo('z')
+
+  -- Cut current line into z register
   cmd('"zdd')
 
   -- Move cursor
@@ -457,7 +461,7 @@ H.make_cmd_normal = function(include_undojoin)
 
     -- Disable 'mini.bracketed' to avoid unwanted entries to its yank history
     local cache_minibracketed_disable = vim.b.minibracketed_disable
-    local cache_unnamed_register = vim.fn.getreg('"')
+    local cache_unnamed_register = { points_to = vim.fn.getreginfo('"').points_to }
 
     -- Don't track possible put commands into yank history
     vim.b.minibracketed_disable = true

--- a/lua/mini/move.lua
+++ b/lua/mini/move.lua
@@ -224,6 +224,10 @@ MiniMove.move_selection = function(direction, opts)
   -- Save original state of z register
   local cache_z_reg = vim.fn.getreginfo('z')
 
+  -- If buffer has no lines, deletion is a no-op and won't set the register, so
+  -- set it to a safe default.
+  vim.fn.setreg('z', '')
+
   -- Cut into z register
   cmd('"zx')
 
@@ -344,6 +348,10 @@ MiniMove.move_line = function(direction, opts)
 
   -- Save original state of z register
   local cache_z_reg = vim.fn.getreginfo('z')
+
+  -- If buffer has no lines, deletion is a no-op and won't set the register, so
+  -- set it to a safe default.
+  vim.fn.setreg('z', '')
 
   -- Cut current line into z register
   cmd('"zdd')

--- a/tests/test_move.lua
+++ b/tests/test_move.lua
@@ -109,6 +109,26 @@ T['move_selection()'] = new_set()
 
 local move = function(direction, opts) child.lua('MiniMove.move_selection(...)', { direction, opts }) end
 
+T['move_selection()']['is no-op on empty buffer'] = function()
+  for _ = 1, 2 do
+    -- First, try with registers unset
+    for _, visual_mode in ipairs({ 'v', 'V' }) do
+      type_keys(visual_mode)
+      for _, direction in ipairs({ 'down', 'up', 'left', 'right' }) do
+        move(direction)
+        validate_state({ '' }, { { 1, 1 }, { 1, 1 } })
+      end
+    end
+
+    -- Try again with " and z registers set
+    child.fn.setreg('"', 'a')
+    child.fn.setreg('z', 'b')
+  end
+
+  eq(child.fn.getreg('"'), 'a')
+  eq(child.fn.getreg('z'), 'b')
+end
+
 T['move_selection()']['works charwise horizontally'] = function()
   -- Test for this many moves because there can be special cases when movement
   -- involves second or second to last character
@@ -909,6 +929,23 @@ T['move_selection()']['respects `vim.{g,b}.minimove_disable`'] = new_set({
 T['move_line()'] = new_set()
 
 local move_line = function(direction, opts) child.lua('MiniMove.move_line(...)', { direction, opts }) end
+
+T['move_line()']['is no-op on empty buffer'] = function()
+  for _ = 1, 2 do
+    -- First, try with registers unset
+    for _, direction in ipairs({ 'down', 'up', 'left', 'right' }) do
+      move_line(direction)
+      validate_state({ '' }, { { 1, 1 }, { 1, 1 } })
+    end
+
+    -- Try again with " and z registers set
+    child.fn.setreg('"', 'a')
+    child.fn.setreg('z', 'b')
+  end
+
+  eq(child.fn.getreg('"'), 'a')
+  eq(child.fn.getreg('z'), 'b')
+end
 
 T['move_line()']['works vertically'] = function()
   set_lines({ 'XX', 'aa', 'bb', 'cc' })


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Currently, calling `move_selection()` or `move_line()` on an empty buffer causes this error:
```
E5108: Error executing lua vim/_editor.lua:0: nvim_exec2(): Vim(normal):E353: Nothing in register z
stack traceback:
        [C]: in function 'nvim_exec2'
        vim/_editor.lua: in function 'cmd'
        .../mini.nvim/lua/mini/move.lua:465: in function 'cmd'
        .../mini.nvim/lua/mini/move.lua:270: in function 'move_selection'
        [string ":lua"]:1: in main chunk
```
If the `z` register is set beforehand, `move_selection()` and `move_line()` insert the contents of `z` into the buffer instead of triggering the error.

This is because `mini.move` assumes that `d` and `x` always set their register, but they don't if they don't change the buffer. I think an empty buffer is the only case where this can happen in visual mode; even with `set selection=exclusive` at least one character is always selected if possible, as confusing as that is. For `move_line()` an empty buffer is still the only case that triggers the bug, but if for instance `"zdi"` were used somewhere, that would also fail to set the `z` register if used on `""`.

`mini.move` also doesn't properly restore the `"` and `z` registers:
- The `0` register is overwritten when restoring the `"` register.
- All register restorations convert the register to either charwise or linewise. Any `NUL` bytes stored in the register are converted to newlines when restoring, which isn't great for all those people who like to put `NUL`s in their code.

These are due to two oversights:
- The `"` register does not actually hold any text, it's only a pointer to another register. `setreg('"', 'foo')` actually sets the `0` register to `foo` and points the `"` register at it.
- `getreg()` only returns the contents of a register, not its type. Setting a register without specifying its type sets it to linewise if the text ends in a newline, and charwise if not. `getreg()` returns a string by default, with `NUL` bytes replaced with newlines due to a quirk of Vim's internal representation of text.

This PR avoids the "nothing in register" error by setting the `z` register to an empty string as a safe default before attempting to cut into it, and replaces `getreg()` with `getreginfo()`, which returns a Dictionary (which behaves as a table in Lua) which holds the entire state of a register and can be passed back to `setreg()` to restore that state.

For saving and restoring the `"` register, only the `points_to` entry is saved; calling `setreg('"')` with a dict/table containing only `points_to` sets the pointee of the `"` register without changing its contents. Calling `setreg('"')` with the saved output of `getreginfo()` without omitting `regcontents` will actually overwrite the contents of the register named by `points_to`, which is a bit of a footgun.

I also added some regression tests which catch the issues I mentioned, except for the clobbering of the `0` register, which could be added to the "has no side effects" tests, I guess.