### PR TITLE
fix(mini.files): correct optional type hint for go_in

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -867,7 +867,7 @@ end
 --- - If file, open it in the window which was current during |MiniFiles.open()|.
 ---   Explorer is not closed after that.
 ---
----@param opts Options. Possible fields:
+---@param opts? Options. Possible fields:
 ---   - <close_on_file> `(boolean)` - whether to close explorer after going
 ---     inside a file. Powers the `go_in_plus` mapping.
 ---     Default: `false`.


### PR DESCRIPTION
Since we do check for opts below, the hint here should be optional

as `go_in()` or `go_in {close_on_file = true}` will work here

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
