### PR TITLE
fix(misc): target stdout stream explicitly

### DIFF
--- a/lua/mini/misc.lua
+++ b/lua/mini/misc.lua
@@ -302,7 +302,7 @@ H.root_cache = {}
 --- Works only on Neovim>=0.10.
 MiniMisc.setup_termbg_sync = function()
   if vim.fn.has('nvim-0.10') == 0 then
-    -- Handling `io.write('\027]11;?\007')` response was added in Neovim 0.10
+    -- Handling `io.stdout:write('\027]11;?\007')` response was added in Neovim 0.10
     H.notify('`setup_termbg_sync()` requires Neovim>=0.10', 'WARN')
     return
   end
@@ -326,13 +326,13 @@ MiniMisc.setup_termbg_sync = function()
     local sync = function()
       local normal = vim.api.nvim_get_hl_by_name('Normal', true)
       if normal.background == nil then return end
-      io.write(string.format('\027]11;#%06x\007', normal.background))
+      io.stdout:write(string.format('\027]11;#%06x\007', normal.background))
     end
     vim.api.nvim_create_autocmd({ 'VimResume', 'ColorScheme' }, { group = augroup, callback = sync })
 
     -- Set up reset to the color returned from the very first call
     H.termbg_init = H.termbg_init or bg_init
-    local reset = function() io.write('\027]11;' .. H.termbg_init .. '\007') end
+    local reset = function() io.stdout:write('\027]11;' .. H.termbg_init .. '\007') end
     vim.api.nvim_create_autocmd({ 'VimLeavePre', 'VimSuspend' }, { group = augroup, callback = reset })
 
     -- Sync immediately
@@ -341,7 +341,7 @@ MiniMisc.setup_termbg_sync = function()
 
   -- Ask about current background color and process the response
   local id = vim.api.nvim_create_autocmd('TermResponse', { group = augroup, callback = f, once = true, nested = true })
-  io.write('\027]11;?\007')
+  io.stdout:write('\027]11;?\007')
   vim.defer_fn(function()
     local ok = pcall(vim.api.nvim_del_autocmd, id)
     if ok then H.notify('`setup_termbg_sync()` did not get response from terminal emulator', 'WARN') end


### PR DESCRIPTION
Use explicit targeting to sync the terminal background. 

Nvim changes standard streams to non-blocking mode, so we should use io.stdout:write to ensure that writes are handled properly (that is, directly addressing the term's standard output).

~~This should address the last remaining bits from #1111:~~

> ~~That's both good (it fixes something) and confusing (it introduces very similar issue for me) news. I'll just focus on the first interpretation :)~~

Let me know how it goes :)