### PR TITLE
docs(files): add example for searching inside a directory

### DIFF
--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -535,6 +535,31 @@ Use |MiniFiles.set_bookmark()| inside `MiniFilesExplorerOpen` event: >lua
     end,
   })
 <
+# Search inside a directory ~
+
+Search inside selected directory using Telescope: >lua
+
+  vim.api.nvim_create_autocmd('User', {
+    pattern = 'MiniFilesWindowUpdate',
+    callback = function(args)
+      local buf_id = args.data.buf_id
+
+      local search_in_directory = function()
+        local fs_entry = MiniFiles.get_fs_entry()
+        if fs_entry.fs_type == 'directory' then
+          MiniFiles.close()
+          local command = 'Telescope live_grep search_dirs=' .. fs_entry.path
+          vim.cmd(command)
+        end
+      end
+
+      vim.keymap.set('n', '<C-f>', search_in_directory, {
+        buffer = buf_id,
+        desc = 'Search in selected directory'
+      })
+    end,
+  })
+<
 ------------------------------------------------------------------------------
                                                              *MiniFiles.setup()*
                           `MiniFiles.setup`({config})


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Thank you for this plugin, `mini.files` is the most ergonomic file explorer I have used. If you are interested, I'd like to contribute this example which I use a lot. I tried to do this using `mini.pick` but couldn't find a way to set search on selected directory using `MiniPick.builtin.grep_live()`.