### PR TITLE
feat(hues): 'nvim-bqf' explicit highlight groups

### DIFF
--- a/lua/mini/hues.lua
+++ b/lua/mini/hues.lua
@@ -1153,6 +1153,19 @@ MiniHues.apply_palette = function(palette, plugins)
   -- 'kevinhwang91/nvim-ufo'
   -- Everything works correctly out of the box
 
+  if has_integration('kevinhwang91/nvim-bqf') then
+    hi('BqfPreviewFloat',      { link = 'NormalFloat' })
+    hi('BqfPreviewBorder',     { link = 'FloatBorder' })
+    hi('BqfPreviewTitle',      { link = 'Title' })
+    hi('BqfPreviewThumb',      { link = 'PmenuThumb' })
+    hi('BqfPreviewSbar',       { link = 'PmenuSbar' })
+    hi('BqfPreviewCursor',     { blend=100, nocombine=true })
+    hi('BqfPreviewCursorLine', { link = 'CursorLine' })
+    hi('BqfPreviewRange',      { link = 'IncSearch' })
+    hi('BqfPreviewBufLabel',   { link = 'BqfPreviewRange' })
+    hi('BqfSign',              { fg=p.cyan })
+  end
+
   if has_integration('lewis6991/gitsigns.nvim') then
     hi('GitSignsAdd',             { fg=p.green,  bg=nil })
     hi('GitSignsAddLn',           { link='GitSignsAdd' })


### PR DESCRIPTION
Add 'nvim-bqf' explicit highlight groups to mini.hues.

##### Before:

![image](https://github.com/user-attachments/assets/7fa39c55-5aae-48a5-b3f7-1d1e9970428d)

##### After:

![image](https://github.com/user-attachments/assets/7472356a-300c-4077-8ed7-2c64581c780a)


- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
