### PR TITLE
docs(bracketed): fix typo

### DIFF
--- a/doc/mini-bracketed.txt
+++ b/doc/mini-bracketed.txt
@@ -62,7 +62,7 @@ Features:
   Window in current tab........... `[W` `[w` `]w` `]W` .... |MiniBracketed.window()|
 
   Yank selection replacing
-  latest put region................`[Y` `[y` `]y` `]Y` .... |MiniBracketed.yank()|
+  latest put region............... `[Y` `[y` `]y` `]Y` .... |MiniBracketed.yank()|
 
 Notes:
 - The `undo` target remaps |u| and |<C-R>| keys to register undo state

--- a/lua/mini/bracketed.lua
+++ b/lua/mini/bracketed.lua
@@ -62,7 +62,7 @@
 ---   Window in current tab........... `[W` `[w` `]w` `]W` .... |MiniBracketed.window()|
 ---
 ---   Yank selection replacing
----   latest put region................`[Y` `[y` `]y` `]Y` .... |MiniBracketed.yank()|
+---   latest put region............... `[Y` `[y` `]y` `]Y` .... |MiniBracketed.yank()|
 ---
 --- Notes:
 --- - The `undo` target remaps |u| and |<C-R>| keys to register undo state


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Hello! Here is a _very_ small docs fix: adds a missing space so that `[Y` is aligned correctly and renders as highlighted.

Thanks so much for mini.nvim, and your help files are the best around!