### PR TITLE
fix(align): prevent undo if no change was made

### DIFF
--- a/lua/mini/align.lua
+++ b/lua/mini/align.lua
@@ -1679,7 +1679,7 @@ H.process_current_region = function(lines_were_set, mode, opts, steps)
   vim.cmd('redraw')
 
   -- Confirm that lines were actually set
-  return true
+  return table.concat(strings) ~= table.concat(strings_aligned)
 end
 
 H.get_current_region = function()

--- a/tests/test_align.lua
+++ b/tests/test_align.lua
@@ -1242,6 +1242,12 @@ T['Align']['works in Visual blockwise mode'] = function()
   validate_keys({ 'ыы_ф', 'ыыы_ф' }, { '1l', '<C-v>', '1j3l', 'ga', '_' }, { 'ыы _ф', 'ыыы_ф' })
 end
 
+T['Align']['works independently with :normal command'] = function()
+  -- Works for each line individually when running under :normal command
+  validate_keys({ 'a   _b', 'aa  _b', 'aaa _b' }, { ':%normal ga_t_<CR>' }, { 'a_b', 'aa_b', 'aaa_b' })
+  validate_keys({ 'a   _  b', 'aa  _  b', 'aaa _  b' }, { ':%normal ga_ A;<CR>' }, { 'a _ b;', 'aa _ b;', 'aaa _ b;' })
+end
+
 T['Align']['registers visual selection'] = function()
   set_lines({ 'a_b', 'aa_b', 'vvv', 'vvv' })
 


### PR DESCRIPTION
Prevent undoing previous actions if no change was made in the current alignment iteration. This is very important, for example, when running alignment under a `:normal` command so it can play well with other actions.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
