### PR TITLE
fix(icons): including filetype icons when mocking `nvim-web-devicons`'s `get_icons()` function

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -598,6 +598,7 @@ MiniIcons.mock_nvim_web_devicons = function()
       { [1] = M.get_default_icon() },
       make_category_tbl('os'),
       make_category_tbl('file'),
+      make_category_tbl('filetype'),
       make_category_tbl('extension')
     )
   end


### PR DESCRIPTION
`nvim-web-devicons`'s `get_icons()` function returns a table of icons which includes the filetype icons, as can be seen here: https://github.com/nvim-tree/nvim-web-devicons/blob/56f17def81478e406e3a8ec4aa727558e79786f3/lua/nvim-web-devicons/icons-default.lua#L994

In the mocking `get_icons()` function, we need to include the `filetype_icons` as well. This fixes an issue when using [barbecue.nvim](https://github.com/utilyre/barbecue.nvim).

Before fix:
![Before_fix](https://github.com/user-attachments/assets/6687af30-cc7d-474d-8c44-d30a38627804)

After fix:
![After_fix](https://github.com/user-attachments/assets/ef7f4a1e-da86-4528-a98b-b3fd5162385a)

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
