### PR TITLE
docs: fix recipes typo

### DIFF
--- a/doc/mini.txt
+++ b/doc/mini.txt
@@ -10,7 +10,7 @@ module can be considered as a separate sub-plugin.
 
 Table of contents:
   General overview ............................................... |mini.nvim|
-  Disabling recepies ........................... |mini.nvim-disabling-recipes|
+  Disabling recipes ............................ |mini.nvim-disabling-recipes|
   Buffer-local config ........................ |mini.nvim-buffer-local-config|
   Plugin colorschemes ................................... |mini-color-schemes|
   Extend and create a/i textobjects ................................ |mini.ai|

--- a/lua/mini/init.lua
+++ b/lua/mini/init.lua
@@ -10,7 +10,7 @@
 ---
 --- Table of contents:
 ---   General overview ............................................... |mini.nvim|
----   Disabling recepies ........................... |mini.nvim-disabling-recipes|
+---   Disabling recipes ............................ |mini.nvim-disabling-recipes|
 ---   Buffer-local config ........................ |mini.nvim-buffer-local-config|
 ---   Plugin colorschemes ................................... |mini-color-schemes|
 ---   Extend and create a/i textobjects ................................ |mini.ai|


### PR DESCRIPTION
Small typo `recepies` to `recipes`

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
