### PR TITLE
feat(deps): support `git@github.com:user/repo` style sources

### DIFF
--- a/lua/mini/deps.lua
+++ b/lua/mini/deps.lua
@@ -984,7 +984,7 @@ H.expand_spec = function(target, spec)
   spec = vim.deepcopy(spec)
 
   if spec.source and type(spec.source) ~= 'string' then H.error('`source` in plugin spec should be string.') end
-  local is_user_repo = type(spec.source) == 'string' and spec.source:find('^[^/]+/[^/]+$') ~= nil
+  local is_user_repo = type(spec.source) == 'string' and spec.source:find('^[^/@]+/[^/]+$') ~= nil
   if is_user_repo then spec.source = 'https://github.com/' .. spec.source end
 
   spec.name = spec.name or vim.fn.fnamemodify(spec.source, ':t')


### PR DESCRIPTION
Exclude `@` characters when detecting `user/repo` style sources while deciding to prepend `https://github.com/`.

- [X] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [X] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
