### PR TITLE
Document tag attribute preservation in `MiniSurround-vim-surround-config` doc

### DIFF
--- a/doc/mini-surround.txt
+++ b/doc/mini-surround.txt
@@ -558,6 +558,20 @@ behavior closest to 'tpope/vim-surround' (but not identical), use this setup: >l
 
   -- Make special mapping for "add surrounding for line"
   vim.keymap.set('n', 'yss', 'ys_', { remap = true })
+
+  -- If preserving tag attributes while replacing was important to you in vim-surround,
+  -- you may add custom `T` surroundings to your setup opts to restore that behavior.
+  -- Avoid remapping over `t` though; Doing so would break surround add / delete.
+  custom_surroundings = {
+    T = {
+      input = { '<(%w-)%f[^<%w][^<>]->.-</%1>', '^<()%w+().*</()%w+()>$' },
+      output = function()
+	local tag_name = MiniSurround.user_input('Tag name')
+	if tag_name == nil then return nil end
+	return { left = tag_name, right = tag_name }
+      end,
+    },
+  }
 <
 # Options ~
 


### PR DESCRIPTION
I noticed that you have a section dedicated to replicating a `tpope/vim-surround` like setup.

Given that a bunch of people have asked about attribute preservation in various issues/discussions, and given the great explanation and workaround you [presented here](https://github.com/echasnovski/mini.nvim/issues/1293#issuecomment-2423827325), maybe this is worth documenting for vim-surround users coming over to mini.surround in that `MiniSurround-vim-surround-config` section? 🙏