### PR TITLE
docs(sessions): add readme note init global session

### DIFF
--- a/readmes/mini-sessions.md
+++ b/readmes/mini-sessions.md
@@ -132,6 +132,8 @@ Here are code snippets for some common installation methods (use only one):
 - Enable corresponding git global config value: `git config --system core.longpaths true`. Then try to reinstall.
 - Install plugin in other place with shorter path.
 
+**Note**: a global session needs to exist before it will be able to read or write, unless a local session is detected. Initialize a global session using `:lua MiniSessions.write('session_name')`.
+
 ## Default config
 
 ```lua


### PR DESCRIPTION
Struggled to figure this out so I thought this might help someone else figure it out sooner. If no global session exists and there is no local session, MiniSessions will not automatically create one.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
