### PR TITLE
fix(pick): support 'ignorecase' in `rg`'s picker

### DIFF
--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -3290,6 +3290,7 @@ H.grep_get_command = function(tool, pattern, globs)
     local res = {
       'rg', '--column', '--line-number', '--no-heading', '--field-match-separator', '\\x00', '--no-follow', '--color=never'
     }
+    if vim.o.ignorecase then table.insert(res, '--ignore-case') end
     for _, g in ipairs(globs) do
       table.insert(res, '--glob')
       -- NOTE: no `*` as default is important to not "override" ignoring files


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

This fixes the `live_grep` behavior when `ignorecase` is enabled. Previously, searching for `todo` in this file would **only** match the lowercase line:
```
// TODO: fix this
// todo: fix this
```

PS: had a couple of tests in `test_pick` fail on me, but this was also the case prior to my PR. Not sure what to do about that.

PS: love your plugins man. <3