### PR TITLE
feat(icons): add a glyph for `norg` filetype

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -1423,7 +1423,7 @@ H.filetype_icons = {
   nim                    = { glyph = '', hl = 'MiniIconsYellow' },
   ninja                  = { glyph = '󰝴', hl = 'MiniIconsGrey'   },
   nix                    = { glyph = '󱄅', hl = 'MiniIconsAzure'  },
-  norg                   = { glyph = '󰫻', hl = 'MiniIconsBlue'   },
+  norg                   = { glyph = '', hl = 'MiniIconsBlue'   },
   nqc                    = { glyph = '󱊈', hl = 'MiniIconsYellow' },
   nroff                  = { glyph = '󰫻', hl = 'MiniIconsCyan'   },
   nsis                   = { glyph = '󰫻', hl = 'MiniIconsAzure'  },


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Nothing much just added a glyph for the 
`norg` filetype :)

![image](https://github.com/user-attachments/assets/36cb3cf1-48d1-4036-9e35-e0d69ea5b02e)
