### PR TITLE
docs(snippets): remove extra param of default_match

### DIFF
--- a/doc/mini-snippets.txt
+++ b/doc/mini-snippets.txt
@@ -649,8 +649,8 @@ Illustration of `config.expand` customization: >lua
     return MiniSnippets.default_prepare(raw_snippets, { context = cont })
   end
   -- Perform fuzzy match based only on alphanumeric characters
-  local my_m = function(snippets, pos)
-    return MiniSnippets.default_match(snippets, pos, {pattern_fuzzy = '%w*'})
+  local my_m = function(snippets)
+    return MiniSnippets.default_match(snippets, { pattern_fuzzy = '%w*' })
   end
   -- Always insert the best matched snippet
   local my_s = function(snippets, insert) return insert(snippets[1]) end

--- a/lua/mini/snippets.lua
+++ b/lua/mini/snippets.lua
@@ -638,8 +638,8 @@ end
 ---     return MiniSnippets.default_prepare(raw_snippets, { context = cont })
 ---   end
 ---   -- Perform fuzzy match based only on alphanumeric characters
----   local my_m = function(snippets, pos)
----     return MiniSnippets.default_match(snippets, pos, {pattern_fuzzy = '%w*'})
+---   local my_m = function(snippets)
+---     return MiniSnippets.default_match(snippets, { pattern_fuzzy = '%w*' })
 ---   end
 ---   -- Always insert the best matched snippet
 ---   local my_s = function(snippets, insert) return insert(snippets[1]) end


### PR DESCRIPTION
  - [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

When adding this [option](https://github.com/xzbdmw/cmp-mini-snippets?tab=readme-ov-file#option) I notice that doc has mismatching arguments ;)
