### PR TITLE
[mini.snippets]: Add new function and documentation

### DIFF
--- a/doc/mini-snippets.txt
+++ b/doc/mini-snippets.txt
@@ -1179,5 +1179,20 @@ Return ~
     - <placeholder> `(table|nil)` - array of nodes to be used as placeholder.
     - <transform> `(table|nil)` - array of transformation string parts.
 
+------------------------------------------------------------------------------
+                                        *MiniSnippets.add_variable_evaluators()*
+                  `MiniSnippets.add_variable_evaluators`({opts})
+Add custom variable evaluators
+
+Parameters ~
+{opts} `(table)` Table of custom evaluators. Possible fields:
+  - <VARIABLE> `(function)` - A function that returns the value of the variable.
+    Example:
+      - `VARIABLE` returns the file name.
+      - Custom variables can be defined, such as current date or user-defined values.
+    Default: `{}`.
+
+Return ~
+`(nil)` This function does not return a value. It modifies the global `H.var_evaluators` table.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/mini/snippets.lua
+++ b/lua/mini/snippets.lua
@@ -1412,6 +1412,38 @@ MiniSnippets.parse = function(snippet_body, opts)
   return opts.normalize and H.parse_normalize(nodes, opts) or nodes
 end
 
+--- Add custom variable evaluators to the global evaluator table.
+---
+--- This function allows you to add or extend the `H.var_evaluators` table with custom evaluators.
+--- The evaluators define dynamic values that can be used within snippets, such as the current line,
+--- selected text, or custom-defined variables.
+---
+--- The provided `opts` will be deeply merged with the existing evaluators, ensuring that the new evaluators
+--- are added without removing any previously defined ones.
+---
+---@param opts table|nil Options for custom variable evaluators. The structure should be a table of key-value pairs
+---   where keys are evaluator names (e.g., `TM_SELECTED_TEXT`) and values are functions that return the
+---   desired evaluation result.
+---
+---   Example:
+---   ```lua
+---   MiniSnippets.add_variable_evaluators({
+---     MY_VARIABLE = function() return "Custom Value" end,
+---   })
+---   ```
+---
+---
+---@usage >lua
+---   -- Add custom evaluators
+---   MiniSnippets.add_variable_evaluators({
+---     MY_CUSTOM_VAR = function() return "Some Value" end,
+---   })
+---
+--- <
+MiniSnippets.add_variable_evaluators = function(opts)
+  H.var_evaluators = vim.tbl_deep_extend('force', H.var_evaluators, opts or {})
+end
+
 -- TODO: Implement this when adding snippet support in 'mini.completion'
 -- MiniSnippets.mock_lsp_server = function() end
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

The function `add_variable_evaluators` is added, allowing users to define custom variable evaluators for snippets. This feature enables greater flexibility in using dynamic values within snippet placeholders.

While exploring, I found [vim-vsnip](https://github.com/hrsh7th/vim-vsnip), which offers a similar feature. This addition felt valuable due to the resemblance and utility, making it a worthwhile feature to include.