### PR TITLE
feat(starter): add support for include/exclude sections

### DIFF
--- a/benchmarks/starter/init-files/init_startify-starter.lua
+++ b/benchmarks/starter/init-files/init_startify-starter.lua
@@ -11,7 +11,7 @@ starter.setup({
   },
   content_hooks = {
     starter.gen_hook.adding_bullet(),
-    starter.gen_hook.indexing('all', { 'Builtin actions' }),
+    starter.gen_hook.indexing('all', { exclude = 'Builtin actions' }),
     starter.gen_hook.padding(3, 2),
   },
 })


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Currently, `MiniStarter.gen_hook.indexing` only has an `exclude_sections` option, and there is no option to specify which sections to include. This cannot be set if the sections are dynamically named (e.g. `MiniStarter.gen_hook.recent_files`).

Therefore, I have changed it so that either include/exclude can be set.

For example,
```lua
-- specify all sections
MiniStarter.gen_hook.indexing('all', 'all')
-- exclude 'built-in actions'
MiniStarter.gen_hook.indexing('all', { exclude = 'Builtin actions' })
-- exclude 'Builtin actions' 'Recent file
MiniStarter.gen_hook.indexing('all', { exclude = { 'Builtin actions', 'Recent files' } }) 
-- include only 'Builtin actions' 'Recent files
MiniStarter.gen_hook.indexing('all', { 'Builtin actions', 'Recent files' })
```