### PR TITLE
fix(starter): empty buffer issue when editing recent file with swapfile

### DIFF
--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -1526,7 +1526,7 @@ H.eval_fun_or_string = function(x, string_as_cmd)
   if type(x) == 'function' then return x() end
   if type(x) == 'string' then
     if string_as_cmd then
-      vim.cmd(x)
+      vim.cmd(("silent! %s"):format(x))
     else
       return x
     end


### PR DESCRIPTION
When `swapfile` is set, a file has an existing swapfile, and the file is listed in the recent files section, editing this file and selecting `e` or `o` in the popup swapfile menu results in an error and ultimately leaves you with an empty buffer, maybe this problem also appears in other similar case. Fix this by add a `silent! ` at the front of `vim.cmd` parameter in `eval_fun_or_string` function.

Reproduce it in gif:
![mini starter-problem](https://github.com/user-attachments/assets/521ac642-bef5-47e2-a17f-0bee4dc79db1)


- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
