### PR TITLE
fix(math/convert): [mini.base16] `xyz2rgb` range miss accurate.

### DIFF
--- a/lua/mini/base16.lua
+++ b/lua/mini/base16.lua
@@ -1463,7 +1463,6 @@ H.xyz2rgb = function(xyz)
   -- stylua: ignore end
 
   return vim.tbl_map(function(c)
-    c = c / 100
     if c > 0.0031308 then
       c = 1.055 * (c ^ (1 / 2.4)) - 0.055
     else


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)


@echasnovski Sorry if it's just me, but I have found a problem with implementation of the paper on concertation. After `luv2xyz` XYZ is in the range [0,1] and `xyz2rgb` [XYZ is also in the nominal range of [0, 1].](http://www.brucelindbloom.com/Eqn_XYZ_to_RGB.html). But all axios `c/100` without any reason.


Also, I don't like the algorithm change, because it is really confusing when I compare it to the original. I understand that it has been made in accordance with the provided link.

And also, I would be very grateful if you provided where you got the conditions from, [like](https://github.com/echasnovski/mini.nvim/blob/9e603a31d3fbc7ee61c9b556cd84e97fa2dcff53/lua/mini/base16.lua#L1487).
