### PR TITLE
feat(clue): allow mapping desc fallback to config clue desc

### DIFF
--- a/lua/mini/clue.lua
+++ b/lua/mini/clue.lua
@@ -1696,7 +1696,7 @@ end
 H.clues_get_all = function(mode)
   local res = {}
 
-  -- Order of clue precedence: config clues < buffer mappings < global mappings
+  -- Order of clue precedence: config clues < global mappings < buffer mappings
   local config_clues = H.clues_normalize(H.get_config().clues) or {}
   local mode_clues = vim.tbl_filter(function(x) return x.mode == mode end, config_clues)
   for _, clue in ipairs(mode_clues) do
@@ -1709,6 +1709,7 @@ H.clues_get_all = function(mode)
     -- - Fall back to possibly already present fields to allow partial
     --   overwrite in later clues. Like to add `postkeys` and inherit `desc`.
     res_data.desc = desc or res_data.desc
+    res_data.desc_fallback = res_data.desc
     res_data.postkeys = H.replace_termcodes(clue.postkeys) or res_data.postkeys
 
     res[lhsraw] = res_data
@@ -1717,14 +1718,14 @@ H.clues_get_all = function(mode)
   for _, map_data in ipairs(vim.api.nvim_get_keymap(mode)) do
     local lhsraw = H.replace_termcodes(map_data.lhs)
     local res_data = res[lhsraw] or {}
-    res_data.desc = map_data.desc or ''
+    res_data.desc = map_data.desc or res_data.desc_fallback or ''
     res[lhsraw] = res_data
   end
 
   for _, map_data in ipairs(vim.api.nvim_buf_get_keymap(0, mode)) do
     local lhsraw = H.replace_termcodes(map_data.lhs)
     local res_data = res[lhsraw] or {}
-    res_data.desc = map_data.desc or ''
+    res_data.desc = map_data.desc or res_data.desc_fallback or ''
     res[lhsraw] = res_data
   end
 


### PR DESCRIPTION
This PR would allow keymaps without descriptions to fallback to the clue description as configured by the user. 
I had also noticed the comment indicating clue precedence was incorrect and corrected it. 

This would allow the user to create clues with dynamic descriptions by providing a function as the clue `desc` and omitting the keymap `desc`. For example, with this change it would be possible to create "toggle" keymaps with clues prefixed by an icon to indicate the toggle state.

However, there would be the drawback that should the user configure a clue description and then create a keymap without any description, then the clue may be incorrect.

I'm wondering what your thoughts are on this change. Would there be an alternative way to display clues with a dynamic description for something like toggle keymaps?

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
