### PR TITLE
fix: use non-deprecated versions of vim.validate

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -1268,22 +1268,32 @@ H.opened_buffers = {}
 -- File system information
 H.is_windows = vim.loop.os_uname().sysname == 'Windows_NT'
 
+local function validate(t)
+  if vim.fn.has('nvim-0.11') == 1 then
+    for k, v in pairs(t) do
+      vim.validate(k, v[1], v[2], v[3])
+    end
+  else
+    vim.validate(t)
+  end
+end
+
 -- Helper functionality =======================================================
 -- Settings -------------------------------------------------------------------
 H.setup_config = function(config)
   -- General idea: if some table elements are not present in user-supplied
   -- `config`, take them from default config
-  vim.validate({ config = { config, 'table', true } })
+  validate({ config = { config, 'table', true } })
   config = vim.tbl_deep_extend('force', vim.deepcopy(H.default_config), config or {})
 
-  vim.validate({
+  validate({
     content = { config.content, 'table' },
     mappings = { config.mappings, 'table' },
     options = { config.options, 'table' },
     windows = { config.windows, 'table' },
   })
 
-  vim.validate({
+  validate({
     ['content.filter'] = { config.content.filter, 'function', true },
     ['content.prefix'] = { config.content.prefix, 'function', true },
     ['content.sort'] = { config.content.sort, 'function', true },

--- a/lua/mini/operators.lua
+++ b/lua/mini/operators.lua
@@ -665,15 +665,25 @@ H.submode_keys = {
   block = vim.api.nvim_replace_termcodes('<C-v>', true, true, true),
 }
 
+local function validate(t)
+  if vim.fn.has('nvim-0.11') == 1 then
+    for k, v in pairs(t) do
+      vim.validate(k, v[1], v[2], v[3])
+    end
+  else
+    vim.validate(t)
+  end
+end
+
 -- Helper functionality =======================================================
 -- Settings -------------------------------------------------------------------
 H.setup_config = function(config)
   -- General idea: if some table elements are not present in user-supplied
   -- `config`, take them from default config
-  vim.validate({ config = { config, 'table', true } })
+  validate({ config = { config, 'table', true } })
   config = vim.tbl_deep_extend('force', vim.deepcopy(H.default_config), config or {})
 
-  vim.validate({
+  validate({
     evaluate = { config.evaluate, 'table' },
     exchange = { config.exchange, 'table' },
     multiply = { config.multiply, 'table' },
@@ -681,7 +691,7 @@ H.setup_config = function(config)
     sort = { config.sort, 'table' },
   })
 
-  vim.validate({
+  validate({
     ['evaluate.prefix'] = { config.evaluate.prefix, 'string' },
     ['evaluate.func'] = { config.evaluate.func, 'function', true },
 

--- a/lua/mini/splitjoin.lua
+++ b/lua/mini/splitjoin.lua
@@ -729,22 +729,32 @@ H.ns_id = vim.api.nvim_create_namespace('MiniSplitjoin')
 
 H.cache = { operator_task = nil }
 
+local function validate(t)
+  if vim.fn.has('nvim-0.11') == 1 then
+    for k, v in pairs(t) do
+      vim.validate(k, v[1], v[2], v[3])
+    end
+  else
+    vim.validate(t)
+  end
+end
+
 -- Helper functionality =======================================================
 -- Settings -------------------------------------------------------------------
 H.setup_config = function(config)
   -- General idea: if some table elements are not present in user-supplied
   -- `config`, take them from default config
-  vim.validate({ config = { config, 'table', true } })
+  validate({ config = { config, 'table', true } })
   config = vim.tbl_deep_extend('force', vim.deepcopy(H.default_config), config or {})
 
-  vim.validate({
+  validate({
     mappings = { config.mappings, 'table' },
     detect = { config.detect, 'table' },
     split = { config.split, 'table' },
     join = { config.join, 'table' },
   })
 
-  vim.validate({
+  validate({
     ['mappings.toggle'] = { config.mappings.toggle, 'string', true },
     ['mappings.split'] = { config.mappings.split, 'string' },
     ['mappings.join'] = { config.mappings.join, 'string', true },


### PR DESCRIPTION
This will remove stack traces from `:checkhealth vim.deprecated`.