### PR TITLE
feat(snippets): better integration with completion engines

### DIFF
--- a/tests/test_snippets.lua
+++ b/tests/test_snippets.lua
@@ -2375,7 +2375,6 @@ T['session.stop()']['works'] = function()
   child.expect_screenshot()
 
   -- Should clean all side effects
-  expect.error(function() child.cmd('au MiniSnippetsTrack') end, 'No such group')
   expect.match(child.cmd_capture('imap <C-h>'), 'No mapping')
   expect.match(child.cmd_capture('imap <C-l>'), 'No mapping')
   expect.match(child.cmd_capture('imap <C-c>'), 'No mapping')
@@ -4953,7 +4952,6 @@ T['Examples']['stop session after Normal mode exit'] = function()
   validate_active_session()
   type_keys('<Esc>')
   validate_no_active_session()
-  eq(child.cmd_capture('au ModeChanged'):find('snippet') == nil, true)
 
   start_session('T1=$1; T0=$0')
   -- Should not stop for "temporary" Normal mode


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

The PR's for both [nvim-cmp](https://github.com/hrsh7th/nvim-cmp/pull/2126) and [blink.cmp](https://github.com/Saghen/blink.cmp/pull/1035) have been merged, adding a `resubscribe` to those engines in order to avoid outdated completion items.

That solution, although fine, has the following disadvantages:

1. The `resubscribe` is an extra line in the user config, needed to connect `mini.snippets` and the completion engine.
2. It does involve some overhead.
3. As @Saghen said [here](https://github.com/Saghen/blink.cmp/pull/1035#issuecomment-2619796846), it is a bit "hacky".

This PR fixes the issue in `mini.snippets` itself.

The `autocommands` in the `MiniSnippetsTracking` group are created in the setup and never deleted. Thus, `mini.snippets` is always "first". Inside the callbacks, the first line is:

```lua
    if not H.is_tracking then return end
```

With these changes, `mini.snippets` works with `nvim-cmp` and `blink.cmp`. Personally, I think this is the best solution. Do feel free of course to close this PR, as I might have missed something.

I also think the solution is slightly more efficient if the user works with `callsnippets` from the `lsp`. In that case, most of the completion will involve `snippets`...


