### PR TITLE
fix(doc): ensure section is not empty when marking optional

### DIFF
--- a/lua/mini/doc.lua
+++ b/lua/mini/doc.lua
@@ -1019,6 +1019,7 @@ H.add_section_heading = function(s, heading)
 end
 
 H.mark_optional = function(s)
+  if #s == 0 or s.type ~= 'section' then return end
   -- Treat question mark at end of first word as "optional" indicator. See:
   -- https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#optional-params
   s[1] = s[1]:gsub('^(%s-%S-)%?', '%1 `(optional)`', 1)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

I encountered the error below that kept the doc generation failing for me, so I added a safe check.

<img width="1360" alt="Screenshot 2025-02-03 at 2 09 08 PM" src="https://github.com/user-attachments/assets/274075ee-07b2-488b-9771-bb044553c3af" />
