### PR TITLE
fix(indentscope): use of global and local variable is consistent with nvim

### DIFF
--- a/lua/mini/indentscope.lua
+++ b/lua/mini/indentscope.lua
@@ -693,7 +693,10 @@ H.create_default_hl = function()
   vim.api.nvim_set_hl(0, 'MiniIndentscopeSymbolOff', { default = true, link = 'MiniIndentscopeSymbol' })
 end
 
-H.is_disabled = function() return vim.g.miniindentscope_disable == true or vim.b.miniindentscope_disable == true end
+H.is_disabled = function()
+  if vim.b.miniindentscope_disable ~= nil then return vim.b.miniindentscope_disable end
+  return vim.g.miniindentscope_disable == true
+end
 
 H.get_config = function(config)
   return vim.tbl_deep_extend('force', MiniIndentscope.config, vim.b.miniindentscope_config or {}, config or {})


### PR DESCRIPTION
After fixing, it can be enabled by whitelisting, and provide more flexibility.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
