### PR TITLE
fix(all): alias replacement is now more accurate

### DIFF
--- a/lua/mini/doc.lua
+++ b/lua/mini/doc.lua
@@ -971,7 +971,17 @@ H.alias_replace = function(s)
       -- two values which might conflict if outputs are used as arguments.
       local name_escaped = vim.pesc(alias_name)
       local desc_escaped = vim.pesc(alias_desc)
-      s[i] = s[i]:gsub(name_escaped, desc_escaped)
+
+      if string.find(desc_escaped, "|", 1, true) then
+        desc_escaped = "(" .. desc_escaped .. ")"
+      end
+
+      local placeholder = "qqqq" .. name_escaped
+      local section_text = s[i]
+      section_text = section_text:gsub("([_%.0-9]+)%f[%a]" .. name_escaped .. "%f[%A]", "%1" .. placeholder)
+      section_text = section_text:gsub("([^_%w]*)%f[%a]" .. name_escaped .. "%f[%A]", "%1" .. desc_escaped)
+      section_text = section_text:gsub("([_%.0-9]+)%f[%a]" .. placeholder .. "%f[%A]", "%1" .. name_escaped)
+      s[i] = section_text
     end
   end
 end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

While working with mini.doc, I noticed that a class type was rendering as `table<string, integer>Bar`. While looking into it, I'd defined an alias called `Foo` and the class's name was originally `FooBar`. The alias replacement accidentally matched the `Foo` part of `FooBar` which resulted in `table<string, integer>Bar`.

This PR is a fix in order to prevent those issues from happening. It matches whole words.

<details>
<summary>See all example replacements</summary>

```lua
local function substitute_current(section_text, alias_name, alias_desc)
  local name_escaped = vim.pesc(alias_name)
  local desc_escaped = vim.pesc(alias_desc)

  return (section_text:gsub(name_escaped, desc_escaped))
end

local function substitute_suggested(section_text, alias_name, alias_desc)
  local name_escaped = vim.pesc(alias_name)
  local desc_escaped = vim.pesc(alias_desc)

  if string.find(desc_escaped, "|", 1, true) then
    desc_escaped = "(" .. desc_escaped .. ")"
  end

  local placeholder = "qqqq"
  section_text = section_text:gsub("([_%.]+)%f[%a]" .. name_escaped .. "%f[%A]", "%1" .. placeholder .. name_escaped)
  section_text = section_text:gsub("([^_%w]*)%f[%a]" .. name_escaped .. "%f[%A]", "%1" .. desc_escaped)
  section_text = section_text:gsub("([_%.]+)%f[%a]" .. placeholder .. name_escaped .. "%f[%A]", "%1" .. name_escaped)

  return section_text
end

local base_entries = {
  -- Exact match whole line
  {"Foo", "Bar"},
  {"Foot", "Foot"},
  {"FooBar", "FooBar"},

  -- Prefix
  {"value Foo", "value Bar"},
  {"name_here Foot", "name_here Foot"},
  {"thing FooBar", "thing FooBar"},

  -- Suffix
  {"Foo value", "Bar value"},
  {"Foot name_here description and words", "Foot name_here description and words"},
  {"FooBar thing", "FooBar thing"},

  -- Infix
  {"something_before Foo value", "something_before Bar value"},
  {"more_things Foot name_here description and words", "more_things Foot name_here description and words"},
  {"blah FooBar thing", "blah FooBar thing"},

  -- Optional
  {"Foo?", "Bar?"},
  {"Foot?", "Foot?"},
  {"FooBar?", "FooBar?"},

  -- Privates
  {"_Foo", "_Foo"},
  {"_Foo?", "_Foo?"},
  {"_Some.Foo.thing?", "_Some.Foo.thing?"},
}

print("Current, broken:")
for _, entry in ipairs(base_entries) do
  local input = entry[1]
  local expected = entry[2]

  -- Replacing Foo with Bar
  local found = substitute_current(input, "Foo", "Bar")

  print(string.format('    Old: "%s"', input))
  print(string.format('    Expected: "%s"', expected))
  print(string.format('    Found: "%s"', found))
  print("\n")
end

print("\nNew, suggested:")
for _, entry in ipairs(base_entries) do
  local input = entry[1]
  local expected = entry[2]

  -- Replacing Foo with Bar
  local found = substitute_suggested(input, "Foo", "Bar")

  print(string.format('    Old: "%s"', input))
  print(string.format('    Expected: "%s"', expected))
  print(string.format('    Found: "%s"', found))
  print("\n")
  assert(expected == found, string.format('Expected: "%s", got "%s".', expected, found))
end


local similar_name_entries = {
  -- Complex
  {"some_var_name fun(variable_name: var, another_var_here: var, last_var: var): (var | Bar)", "some_var_name fun(variable_name: mar, another_var_here: mar, last_var: mar): (mar | Bar)"}
}

print("Current, functions, broken:")

for _, entry in ipairs(similar_name_entries) do
  local input = entry[1]
  local expected = entry[2]

  -- Replacing Foo with Bar
  local found = substitute_current(input, "var", "mar")

  print(string.format('    Old: "%s"', input))
  print(string.format('    Expected: "%s"', expected))
  print(string.format('    Found: "%s"', found))
  print("\n")
end

print("\nNew, functions:")

for _, entry in ipairs(similar_name_entries) do
  local input = entry[1]
  local expected = entry[2]

  -- Replacing Foo with Bar
  local found = substitute_suggested(input, "var", "mar")

  print(string.format('    Old: "%s"', input))
  print(string.format('    Expected: "%s"', expected))
  print(string.format('    Found: "%s"', found))
  print("\n")
  assert(expected == found, string.format('Expected: "%s", got "%s".', expected, found))
end
```
</details>

In the example code above, `substitute_current` represents the current mini.doc alias replacement. And `substitute_suggested` is this PR. As you can see, `substitute_current` has many false positives and `substitute_suggested` is working in every defined case.

## How It Works
`%f[%a] ... %f[%A]` matches whole words, which is great for what we need. Just one problem - `_` and `.` are not considered part of a word. So `var` or `Foo` in `fun(some_var_name: string, another: some.Foo.blah): nil` might accidentally get matched even if we don't mean to.

To prevent that from happening, we find all of those matches, prefix it with a unique string (in this case, `qqqq`), then do the replacement (which otherwise is perfect except for that one bug) and then remove the `qqqq` placeholder again.

The result is an all-around better alias replacement outcome.

## Caveats
There's likely a simpler regex that can do the job. Just that considering `fun(foo: bar, fizz: buzz): (extra | thing)` syntax and the possibility of nested types, this was the best I could come up with, quickly.