### PR TITLE
feat(files): add autocommand events before performing file actions

### DIFF
--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -354,13 +354,23 @@ with the following information:
 
 File action events ~
 
+- `MiniFilesActionCreatePre` - before entry is created.
+
 - `MiniFilesActionCreate` - after entry is successfully created.
+
+- `MiniFilesActionDeletePre` - before entry is deleted.
 
 - `MiniFilesActionDelete` - after entry is successfully deleted.
 
+- `MiniFilesActionRenamePre` - before entry is renamed.
+
 - `MiniFilesActionRename` - after entry is successfully renamed.
 
+- `MiniFilesActionCopyPre` - before entry is copied.
+
 - `MiniFilesActionCopy` - after entry is successfully copied.
+
+- `MiniFilesActionMovePre` - before entry is moved.
 
 - `MiniFilesActionMove` - after entry is successfully moved.
 


### PR DESCRIPTION
The exposed autocommands make it very easy to add support for things such as the file operations defined in the LSP specification. Currently there are some events missing immediately before an operation is taken to support the rest of the events (`workspace/willCreateFiles`/`workspace/willDeleteFiles`/`workspace/willRenameFiles`). I'm sure there are other use cases as well where the user may want to hook into events right before an action is taken place.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
