### PR TITLE
feat(files): add an option to persist bookmarks

### DIFF
--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -606,6 +606,8 @@ Default values:
       permanent_delete = true,
       -- Whether to use for editing directories
       use_as_default_explorer = true,
+      -- Whether to persist bookmarks (per root directory)
+      persist_bookmarks = false
     },
 
     -- Customization of explorer windows
@@ -683,6 +685,13 @@ Note: to work with directory in |arglist|, do not lazy load this module.
 permanent delete or move into special trash directory.
 This is a module-specific variant of "remove to trash".
 Target directory is 'mini.files/trash' inside standard path of Neovim data
+directory (execute `:echo stdpath('data')` to see its path in your case).
+
+`options.persist_bookmarks` is a boolean indicating whether to persist bookmarks
+made while using this plugin. The bookmarks are persisted per current working directory, 
+that means that they get restored if you open neovim from the same directory you made
+them in.
+Target directory is 'mini.files/bookmarks' inside standard path of Neovim data
 directory (execute `:echo stdpath('data')` to see its path in your case).
 
 # Windows ~
@@ -975,6 +984,40 @@ Parameters ~
 
 Return ~
 `(table)` Sorted array of file system entries.
+
+------------------------------------------------------------------------------
+                                                  *H.save_persisted_bookmarks()*
+                `H.save_persisted_bookmarks`({explorer}, {path})
+Saves bookmarks to disk if the configuration option is enabled
+Parameters ~
+{explorer} `(any)` The explorer to persist
+{path} `(string|function)` The newly added path, this is only to typecheck whether it
+a string because functions are not supported
+
+------------------------------------------------------------------------------
+                                               *H.restore_persisted_bookmarks()*
+                  `H.restore_persisted_bookmarks`({explorer})
+Restores persisted bookmarks from disk
+Parameters ~
+{explorer} `(any)`
+
+------------------------------------------------------------------------------
+                                                                 *H.serialize()*
+                              `H.serialize`({tab})
+Serializes a table
+Parameters ~
+{tab} `(table)` Table to be serialized
+Return ~
+`(string)` A string representation of a table
+
+------------------------------------------------------------------------------
+                                                               *H.deserialize()*
+                              `H.deserialize`({s})
+Deserializes a string to a table
+Parameters ~
+{s} `(string)` The serialized table
+Return ~
+`(table)` The deserialized table
 
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -985,39 +985,5 @@ Parameters ~
 Return ~
 `(table)` Sorted array of file system entries.
 
-------------------------------------------------------------------------------
-                                                  *H.save_persisted_bookmarks()*
-                `H.save_persisted_bookmarks`({explorer}, {path})
-Saves bookmarks to disk if the configuration option is enabled
-Parameters ~
-{explorer} `(any)` The explorer to persist
-{path} `(string|function)` The newly added path, this is only to typecheck whether it
-a string because functions are not supported
-
-------------------------------------------------------------------------------
-                                               *H.restore_persisted_bookmarks()*
-                  `H.restore_persisted_bookmarks`({explorer})
-Restores persisted bookmarks from disk
-Parameters ~
-{explorer} `(any)`
-
-------------------------------------------------------------------------------
-                                                                 *H.serialize()*
-                              `H.serialize`({tab})
-Serializes a table
-Parameters ~
-{tab} `(table)` Table to be serialized
-Return ~
-`(string)` A string representation of a table
-
-------------------------------------------------------------------------------
-                                                               *H.deserialize()*
-                              `H.deserialize`({s})
-Deserializes a string to a table
-Parameters ~
-{s} `(string)` The serialized table
-Return ~
-`(table)` The deserialized table
-
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -2931,6 +2931,7 @@ end
 ---@param explorer any The explorer to persist
 ---@param path string|function The newly added path, this is only to typecheck whether it
 ---is a string because functions are not supported
+---@private
 H.save_persisted_bookmarks = function(explorer, path)
   if explorer.opts.options.persist_bookmarks then
     if not (type(path) == 'string') then H.error('Persisting bookmarks only support strings as paths.') end
@@ -2947,6 +2948,7 @@ end
 
 --- Restores persisted bookmarks from disk
 ---@param explorer any
+---@private
 H.restore_persisted_bookmarks = function(explorer)
   local path = H.get_persist_file_path()
   if not explorer.opts.options.persist_bookmarks then return end
@@ -2962,6 +2964,7 @@ end
 --- Serializes a table
 ---@param tab table Table to be serialized
 ---@return string A string representation of a table
+---@private
 H.serialize = function(tab)
   Pickle = {
     clone = function(t)
@@ -3025,6 +3028,7 @@ end
 --- Deserializes a string to a table
 ---@param s string The serialized table
 ---@return table The deserialized table
+---@private
 H.deserialize = function(s)
   if type(s) ~= 'string' then H.error("can't unpickle a " .. type(s) .. ', only strings') end
   local gentables = loadstring('return ' .. s)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Added a feature to persist bookmarks to disk so they are saved when you open from the same directory again. Currently they are saved per current working directory and restored upon opening the explorer. 

If it's possible I would like some suggestions on how to better integrate it with the existing structure of the mini.files plugin (like the history and tabs). If the current approach with the cwd is good enough I would like just the go ahead before I start writing tests.

Tests aren't yet written because currently the way the bookmarks are persisted is subject to change. 