### PR TITLE
fix(completion): validation of process_items

### DIFF
--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -595,7 +595,7 @@ H.setup_config = function(config)
     H.error('`lsp_completion.source_func` should be one of "completefunc" or "omnifunc"')
   end
   H.check_type('lsp_completion.auto_setup', config.lsp_completion.auto_setup, 'boolean')
-  H.check_type('lsp_completion.process_items', config.lsp_completion.process_items, 'nil')
+  H.check_type('lsp_completion.process_items', config.lsp_completion.process_items, 'callable')
 
   H.check_type('mappings.force_twostep', config.mappings.force_twostep, 'string')
   H.check_type('mappings.force_fallback', config.mappings.force_fallback, 'string')


### PR DESCRIPTION
This patch addresses a recent regression where an error would be raised if lsp_completion.process_items was set.
The validation now behaves as expected: it raises if lsp_completion.process_items is set to something that is not a function.