### PR TITLE
fix: Sanitize H.get_comment_leaders() in mini.snippets

### DIFF
--- a/lua/mini/snippets.lua
+++ b/lua/mini/snippets.lua
@@ -2530,14 +2530,16 @@ H.get_comment_leaders = function()
   -- From 'comments'
   for _, comment_part in ipairs(vim.opt_local.comments:get()) do
     local prefix, suffix = comment_part:match('^(.*):(.*)$')
-    suffix = vim.trim(suffix)
-    if prefix:find('b') then
-      -- Respect `b` flag (for blank) requiring space, tab or EOL after it
-      table.insert(res, suffix .. ' ')
-      table.insert(res, suffix .. '\t')
-    elseif prefix:find('f') == nil then
-      -- Add otherwise ignoring `f` flag (only first line should have it)
-      table.insert(res, suffix)
+    if suffix ~= nil then
+      suffix = vim.trim(suffix)
+      if prefix:find('b') then
+        -- Respect `b` flag (for blank) requiring space, tab or EOL after it
+        table.insert(res, suffix .. ' ')
+        table.insert(res, suffix .. '\t')
+      elseif prefix:find('f') == nil then
+        -- Add otherwise ignoring `f` flag (only first line should have it)
+        table.insert(res, suffix)
+      end
     end
   end
 


### PR DESCRIPTION
When comment_part in H.get_comment_leaders() is empty we get a nil value for suffix, which then breaks vim.trim(suffix). Sanitize this function for this case.

Fixes bug #1657.

- [X] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [X] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
