### PR TITLE
fix(completion): handle edit range properly in `apply_item_defaults`

### DIFF
--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -993,10 +993,12 @@ H.apply_item_defaults = function(items, defaults)
       -- Infer new text from `item.textEditText` designed for default edit case
       item.textEdit.newText = item.textEdit.newText or item.textEditText or item.label
       -- Default `editRange` is range (start+end) or insert+replace ranges
-      item.textEdit.start = item.textEdit.start or edit_range.start
-      item.textEdit['end'] = item.textEdit['end'] or edit_range['end']
-      item.textEdit.insert = item.textEdit.insert or edit_range.insert
-      item.textEdit.replace = item.textEdit.replace or edit_range.replace
+      if edit_range.start then
+        item.textEdit.range = item.textEdit.range or edit_range
+      elseif edit_range.insert then
+        item.textEdit.insert = item.textEdit.insert or edit_range.insert
+        item.textEdit.replace = item.textEdit.replace or edit_range.replace
+      end
     end
   end
   return items


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
Hi echasnovski, thanks for another great work. I found out that `editRange` in `itemDefaults` didn't handle properly, according to https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem, the `texitEdit` in `completionItem` should be [TextEdit](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textEdit) or [InsertReplaceEdit](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#insertReplaceEdit), but now if it's a `TextEdit`, the code here handle it as a [Range](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#range), which it's just a part of `TextEdit` structure. this could cause some problem, for me it make `jdtls` didn't response with the completion item's documentation.
related to #886.