### PR TITLE
fix(completion): check lsp result for both err and error key

### DIFF
--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -981,7 +981,9 @@ H.process_lsp_response = function(request_result, processor)
 
   local res = {}
   for client_id, item in pairs(request_result) do
-    if not item.err and item.result then vim.list_extend(res, processor(item.result, client_id) or {}) end
+    if not (item.err or item.error) and item.result then
+      vim.list_extend(res, processor(item.result, client_id) or {})
+    end
   end
 
   return res
@@ -1124,7 +1126,7 @@ end
 H.make_lsp_extra_actions = function(lsp_data)
   -- Prefer resolved item over the one from 'textDocument/completion'
   local resolved = (H.info.lsp.result or {})[lsp_data.client_id]
-  local item = (resolved == nil or resolved.err) and lsp_data.completion_item or resolved.result
+  local item = (resolved == nil or resolved.err or resolved.error) and lsp_data.completion_item or resolved.result
 
   if item.additionalTextEdits == nil and not lsp_data.needs_snippet_insert then return end
   local snippet = lsp_data.needs_snippet_insert and H.get_completion_word(item) or nil
@@ -1611,7 +1613,7 @@ H.get_completion_start = function(lsp_result)
 end
 
 H.get_completion_start_server = function(response_data, line_num)
-  if response_data.err or type(response_data.result) ~= 'table' then return end
+  if response_data.err or response_data.error or type(response_data.result) ~= 'table' then return end
   local items = response_data.result.items or response_data.result
   for _, item in pairs(items) do
     if type(item.textEdit) == 'table' then


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

This PR fixes the error mentioned in [this](https://github.com/echasnovski/mini.nvim/discussions/1681) discussion: Setting up completion + snippets fails.

I added `or item.error` to three locations, and tested on both v0.10.4 and nightly according to the setup used in the discussion.

I tried to copy and modify testcase `prefer snippet from resolved item`. Unfortunately I could not reliably test the premise.
