### PR TITLE
feat(misc): trigger nested autocommands in setup_auto_root

### DIFF
--- a/lua/mini/misc.lua
+++ b/lua/mini/misc.lua
@@ -212,7 +212,7 @@ MiniMisc.setup_auto_root = function(names, fallback)
   local augroup = vim.api.nvim_create_augroup('MiniMiscAutoRoot', {})
   vim.api.nvim_create_autocmd(
     'BufEnter',
-    { group = augroup, callback = set_root, desc = 'Find root and change current directory' }
+    { group = augroup, callback = set_root, desc = 'Find root and change current directory', nested = true }
   )
 end
 

--- a/tests/test_misc.lua
+++ b/tests/test_misc.lua
@@ -347,6 +347,18 @@ T['setup_auto_root()']['works in buffers without path'] = function()
   eq(getcwd(), cur_dir)
 end
 
+T['setup_auto_root()']['trigger nested autocommands'] = function()
+  setup_auto_root()
+
+  child.api.nvim_set_var('triggered', false)
+  eq(child.api.nvim_get_var('triggered'), false)
+
+  child.api.nvim_create_autocmd('DirChanged', {command = 'let g:triggered = v:true'})
+
+  child.cmd('edit ' .. test_file_makefile)
+  eq(child.api.nvim_get_var('triggered'), true)
+end
+
 T['find_root()'] = new_set({ hooks = { post_case = cleanup_mock_git } })
 
 local find_root = function(...) return child.lua_get('MiniMisc.find_root(...)', { ... }) end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Hello,

I'm currently developping a small plugin that performs some actions when the current directory is changed. It works by defining autocommands triggered on [`DirChanged`](https://neovim.io/doc/user/autocmd.html#DirChanged) events.

However these autocommands are not triggered by `setup_auto_root`. This is because by default, autocommands are not triggered inside another autocommand ([source](https://neovim.io/doc/user/autocmd.html#autocmd-nested)).

This PR changes that by setting the `nested` option to `true` when creating the autocommand in `setup_auto_root`.

It should not trigger any other events than `DirChanged` and `DirChangedPre` since the callback of `setup_auto_root` basically only calls `vim.fn.chdir()`, and it seems logical to allow those two events to be triggered.

Thanks for this great suite of plugins by the way :)