### PR TITLE
Pass `actions` to custom mapping `<func>`

### DIFF
--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -2171,9 +2171,14 @@ H.picker_advance = function(picker)
     do_match = cur_action.name == nil or vim.startswith(cur_action.name, 'delete') or cur_action.name == 'paste'
     is_aborted = cur_action.name == 'stop'
 
+	local actions = {}
+	for name, fn in pairs(H.actions) do
+		actions[name] = function() return fn(picker, char) end
+	end
+
     local should_stop
     if cur_action.is_custom then
-      should_stop = cur_action.func()
+      should_stop = cur_action.func(actions)
     else
       should_stop = (cur_action.func or H.picker_query_add)(picker, char)
     end

--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -595,16 +595,25 @@
 --- name (used to infer an action description in info view). The value is a table
 --- with the following fields:
 --- - <char> `(string)` - single character acting as action trigger.
---- - <func> `(function)` - callable to be executed without arguments after
----   user presses <char>. Its return value is treated as "should stop picker
----   after execution", i.e. returning nothing, `nil`, or `false` continues
----   picker while everything else (prefer `true`) stops it.
+--- - <func> `(function)` - callable which accept one argument - table with
+--- actions (see :help MiniPick-actions). <func> will be executed after user
+--- presses <char>. Its return value is treated as "should stop picker after
+--- execution", i.e. returning nothing, `nil`, or `false` continues picker
+--- while everything else (prefer `true`) stops it.
 ---
 --- Example of `execute` custom mapping: >lua
 ---
 ---   execute = {
 ---     char = '<C-e>',
 ---     func = function() vim.cmd(vim.fn.input('Execute: ')) end,
+---   }
+---
+---   mark_and_move_down = {
+---     char = '<Tab>',
+---     func = function(a)
+---     	a.mark()
+---     	a.move_down()
+---     end,
 ---   }
 --- <
 ---@tag MiniPick-actions


### PR DESCRIPTION
- **feat(pick): pass actions to custom mapping function**
- **docs(pick): document custom mapping function**

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Hey, I suggest to pass table with actions to custom mapping function. This
allow more customization. E.g. I want to configure keybindings similar to fzf.
In fzf `<Tab>` mark current item and move to next. To reproduce this in
Mini.Pick I need access to actions in my custom mapping function.

How I used this you can see in my [config](https://github.com/feelamee/dotfiles/blob/5ce29b6d769ab51d33b12f0304fd5433e76a5a74/nvim/init.lua#L188).

This feature don't introduce breaking changes. That's why it can be easily merged.
