### PR TITLE
docs(colors): fix typo in MiniColors.setup()

### DIFF
--- a/doc/mini-colors.txt
+++ b/doc/mini-colors.txt
@@ -669,7 +669,7 @@ Module setup
 Calling this function creates a `:Colorscheme` user command. It takes one or
 more registered color scheme names and performs animated transition between
 them (starting from currently active color scheme).
-It uses |MiniColors.animte()| with default options.
+It uses |MiniColors.animate()| with default options.
 
 Parameters ~
 {config} `(table|nil)` Module config table. See |MiniColors.config|.

--- a/lua/mini/colors.lua
+++ b/lua/mini/colors.lua
@@ -636,7 +636,7 @@ local H = {}
 --- Calling this function creates a `:Colorscheme` user command. It takes one or
 --- more registered color scheme names and performs animated transition between
 --- them (starting from currently active color scheme).
---- It uses |MiniColors.animte()| with default options.
+--- It uses |MiniColors.animate()| with default options.
 ---
 ---@param config table|nil Module config table. See |MiniColors.config|.
 ---


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)


"animte" -> "animate"
