### PR TITLE
fix(align): handle empty list and empty strings properly

### DIFF
--- a/doc/mini-colors.txt
+++ b/doc/mini-colors.txt
@@ -669,7 +669,7 @@ Module setup
 Calling this function creates a `:Colorscheme` user command. It takes one or
 more registered color scheme names and performs animated transition between
 them (starting from currently active color scheme).
-It uses |MiniColors.animte()| with default options.
+It uses |MiniColors.animate()| with default options.
 
 Parameters ~
 {config} `(table|nil)` Module config table. See |MiniColors.config|.

--- a/lua/mini/align.lua
+++ b/lua/mini/align.lua
@@ -1617,11 +1617,13 @@ H.default_action_merge = function(parts, opts)
   end
 
   -- Do not change indentation
-  local first_parts_are_indent = true
-  for i = 1, dims.row do
-    first_parts_are_indent = first_parts_are_indent and H.is_whitespace(parts[i][1])
+  if #delimiter_arr > 0 then
+    local first_parts_are_indent = true
+    for i = 1, dims.row do
+      first_parts_are_indent = first_parts_are_indent and H.is_whitespace(parts[i][1])
+    end
+    delimiter_arr[1] = first_parts_are_indent and delimiter_arr[1]:gsub('^%s*', '') or delimiter_arr[1]
   end
-  delimiter_arr[1] = first_parts_are_indent and delimiter_arr[1]:gsub('^%s*', '') or delimiter_arr[1]
 
   return vim.tbl_map(function(row) return H.concat_array(row, delimiter_arr) end, parts)
 end

--- a/lua/mini/colors.lua
+++ b/lua/mini/colors.lua
@@ -636,7 +636,7 @@ local H = {}
 --- Calling this function creates a `:Colorscheme` user command. It takes one or
 --- more registered color scheme names and performs animated transition between
 --- them (starting from currently active color scheme).
---- It uses |MiniColors.animte()| with default options.
+--- It uses |MiniColors.animate()| with default options.
 ---
 ---@param config table|nil Module config table. See |MiniColors.config|.
 ---

--- a/tests/test_align.lua
+++ b/tests/test_align.lua
@@ -953,6 +953,13 @@ T['gen_step']['default_merge()']['works'] = function()
   )
 end
 
+T['gen_step']['default_merge()']['indentity for empty list and zero-length strings'] = function()
+  validate_align_strings({}, {}, {})
+  validate_align_strings({ '' }, {}, { '' })
+  validate_align_strings({ '', '' }, {}, { '', '' })
+  validate_align_strings({ '', ' ' }, {}, { '', ' ' })
+end
+
 T['gen_step']['default_merge()']['verifies relevant options'] = function()
   expect.error(
     function() child.lua([[MiniAlign.align_strings({ 'a' }, { merge_delimiter = 1 }, {})]]) end,


### PR DESCRIPTION
This fixes a bug introduced in b83127c36cc7a9f3cb9e16f5d9db1231d30c33f9. In summary, these calls started to fail after that commit:

```
MiniAlign.align_strings({})
MiniAlign.align_strings({""})
MiniAlign.align_strings({"", ""})
```

I noticed that a custom picker of mine broke recently, but hadn't had time to chase down what happened until this morning. I use `MiniAlign.align_strings` in a picker.source.show function to pretty things up with live grep. At the start of that picker, there are no items, so `align_strings` was being passed `{}` and erroring out. Prior to the change mentioned above, my picker worked without error.

The following PR addresses the issue. I also added tests (now that I recently learned how to do so with your awesome 'mini.test'—thank you).

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
