### PR TITLE
feat(jump): add on_key listener for esc to stop jumping

### DIFF
--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -350,6 +350,7 @@ H.create_autocommands = function()
   au('CursorMoved', '*', H.on_cursormoved, 'On CursorMoved')
   au({ 'BufLeave', 'InsertEnter' }, '*', MiniJump.stop_jumping, 'Stop jumping')
   au('ColorScheme', '*', H.create_default_hl, 'Ensure colors')
+  vim.on_key(H.on_key)
 end
 
 H.create_default_hl = function() vim.api.nvim_set_hl(0, 'MiniJump', { default = true, link = 'SpellRare' }) end
@@ -389,6 +390,17 @@ H.on_cursormoved = function()
     H.cache.n_cursor_moved = H.cache.n_cursor_moved + 1
     -- Stop jumping only if `CursorMoved` was not a result of smart jump
     if H.cache.n_cursor_moved > 1 then MiniJump.stop_jumping() end
+  end
+end
+
+H.on_key = function(char)
+  -- Check if jumping to avoid unnecessary actions on every on_key
+  if MiniJump.state.jumping then
+    local key = vim.fn.keytrans(char)
+    if key == '<Esc>' then
+      -- Stop jumping if user pressed `<Esc>`
+      MiniJump.stop_jumping()
+    end
   end
 end
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [ ] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Hey, big fan. I noticed that sometimes I want to jump to something, then realize I wanted to jump to something else. Stopping the jump on cursor move works, but I happen to have muscle memory to mash escape whenever I want to "cancel" something. This PR adds a simple on_key listener for escape to stop jumping in a similar vein to the on_cursormoved callback