### PR TITLE
feat(jump): add get_target_callback option

### DIFF
--- a/doc/mini-jump.txt
+++ b/doc/mini-jump.txt
@@ -97,6 +97,11 @@ Default values:
     -- This also affects (purely informational) helper messages shown after
     -- idle time if user input is required.
     silent = false,
+
+    -- Optional callback to be triggered when waiting for target input
+    -- Useful for combining mini.jump with other plugins that also want
+    -- to modify f/t/F/T behavior.
+    get_target_callback = function(_backward) end
   }
 <
 ------------------------------------------------------------------------------


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Another little PR to add an optional callback that triggers when mini.jump calls `get_target`. I'm mainly hoping to add this so that I can more easily integrate `eyeliner.nvim` like so:

```lua
{
	'echasnovski/mini.jump',
	dependencies = {
		"jinh0/eyeliner.nvim",
	},
	opts = {
		get_target_callback = function(backward)
			require("eyeliner").highlight({ forward = not backward })
		end
	},
	config = function(_, opts)
		require('mini.jump').setup(opts)
	end
}

