### PR TITLE
refactor(jump2d): remove two redundant lines of code

### DIFF
--- a/lua/mini/jump2d.lua
+++ b/lua/mini/jump2d.lua
@@ -680,9 +680,7 @@ local function user_input_opts(input_fun)
   res.hooks = {
     before_start = function()
       local input = input_fun()
-      if input == nil then
-        res.spotter = function() return {} end
-      else
+      if input ~= nil then
         local pattern = vim.pesc(input)
         res.spotter = MiniJump2d.gen_spotter.pattern(pattern)
       end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

`res.spotter` is already initialized for the `nil` input case.
