### PR TITLE
docs(jump2d): fix typo

### DIFF
--- a/doc/mini-jump2d.txt
+++ b/doc/mini-jump2d.txt
@@ -241,7 +241,7 @@ Vimscript functions that operate only inside current window.
 ## View ~
 
 Option `view.n_steps_ahead` controls how many steps ahead to show along
-with the currently required label. Those future steps are showed with
+with the currently required label. Those future steps are shown with
 different (less visible) highlight group ("MiniJump2dSpotAhead"). Usually
 it is a good idea to use this with a spotter which doesn't result into many
 jump spots (like, for example, |MiniJump2d.builtin_opts.word_start|).


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

I read through the code because of issue 1818 and found two spelling errors.

If you'd like, I can also push an extra commit:

- Change line 22 into:

```txt
---       before/at/after cursor line, etc.
---     Example: user can configure to look for spots only inside current
---     window at or after cursor line.

```

- Change line 79 into:

```txt
--- - Jump to line start using combination of options supplied in
```

- Change line 343 into:

```txt
---@param opts table|nil Configuration of jumping, overriding global and buffer
---   local values. Has the same structure as |MiniJump2d.config|
---   without <mappings> field. Extra allowed fields:
```

- Change line 360 into:

```txt
---   -- Jump to single character from user input
---   MiniJump2d.start(MiniJump2d.builtin_opts.single_character)
```

- Change line 561 into:

```txt
  if #spotters == 0 then
    return function() return {} end
  end

```

Line 561 always auto formats.

