### PR TITLE
docs(readme): improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ if not vim.loop.fs_stat(mini_path) then
   }
   vim.fn.system(clone_cmd)
   vim.cmd('packadd mini.nvim | helptags ALL')
+  vim.cmd('echo "Installed `mini.nvim`" | redraw')
 end
 ```
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Hi, as I was installing mini.nvim for the first time today, I've noticed that ```vim.cmd('echo "Installed `mini.nvim`" | redraw') ``` was added in deps docs https://github.com/echasnovski/mini.nvim/blob/main/readmes/mini-deps.md but not in the main readme. 

If it was intentional, feel free to discard. Thanks