### PR TITLE
fix(keymap): check if Blink menu is visible before accepting selection

### DIFF
--- a/lua/mini/keymap.lua
+++ b/lua/mini/keymap.lua
@@ -806,7 +806,7 @@ H.steps_builtin.cmp_prev   = { condition = H.is_visible_cmp,  action = H.make_cm
 H.steps_builtin.cmp_accept = { condition = H.is_selected_cmp, action = H.make_cmp_action('confirm') }
 
 H.is_visible_blink  = function() return H.has_module('blink.cmp') and require('blink.cmp').is_menu_visible() end
-H.is_selected_blink = function() return H.has_module('blink.cmp') and require('blink.cmp').get_selected_item() ~= nil end
+H.is_selected_blink = function() return H.has_module('blink.cmp') and require('blink.cmp').is_menu_visible() and require('blink.cmp').get_selected_item() ~= nil end
 H.make_blink_action = function(action) return H.make_cmd_lua_action('require("blink.cmp").' .. action .. '()') end
 
 H.steps_builtin.blink_next   = { condition = H.is_visible_blink,  action = H.make_blink_action('select_next') }


### PR DESCRIPTION
## Description

`get_selected_item()` still returns the last selected item even after the completion menu is closed, which causes the `blink_accept` action to always be chosen instead of any other following steps.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

## Context

I use Blink with the `super-tab` preset where `<Tab>` accepts the completion, and noticed that the multi-step keymap stopped working after the completion menu was shown at least once.

`mini.keymap` example setup:

```lua
      keymap.map_multistep('i', '<Tab>', {
        'blink_accept',
        'vimsnippet_next',
        'increase_indent',
        'jump_after_close',
    })
```

`blink.cmp` example setup:

```lua
    keymap = {
      preset = 'super-tab',

      -- mapped with `mini.keymap`
      ['<Tab>'] = {},
      ['<S-Tab>'] = {},
    }
```