### PR TITLE
feat(ai): take matches with multiple nodes into account

### DIFF
--- a/lua/mini/ai.lua
+++ b/lua/mini/ai.lua
@@ -1569,8 +1569,10 @@ H.get_matched_ranges_builtin = function(captures)
   lang_tree:parse(false)
 
   local res = {}
+  -- TODO: Remove after compatibility with Neovim=0.10 is dropped
+  local opts = { all = true }
   for _, tree in ipairs(lang_tree:trees()) do
-    for _, match, metadata in query:iter_matches(tree:root(), 0) do
+    for _, match, metadata in query:iter_matches(tree:root(), 0, nil, nil, opts) do
       for capture_id, nodes in pairs(match) do
         if capture_is_requested[capture_id] then
           metadata = (metadata or {})[capture_id] or {}

--- a/lua/mini/ai.lua
+++ b/lua/mini/ai.lua
@@ -1566,7 +1566,7 @@ H.get_matched_ranges_builtin = function(captures)
   -- Compute ranges of matched captures
   local capture_is_requested = vim.tbl_map(function(c) return vim.tbl_contains(captures, '@' .. c) end, query.captures)
 
-  parser:parse(true)
+  lang_tree:parse(false)
 
   local res = {}
   for _, tree in ipairs(lang_tree:trees()) do

--- a/lua/mini/surround.lua
+++ b/lua/mini/surround.lua
@@ -1545,7 +1545,7 @@ H.get_matched_range_pairs_builtin = function(captures)
   local query = vim.treesitter.query.get(lang, 'textobjects')
   if query == nil then H.error_treesitter('query') end
 
-  parser:parse(true)
+  lang_tree:parse(false)
 
   -- Compute matches for outer capture
   local outer_matches = {}

--- a/lua/mini/surround.lua
+++ b/lua/mini/surround.lua
@@ -1568,7 +1568,9 @@ end
 H.get_builtin_matches = function(capture, root, query, buf_id)
   local res = {} ---@type Range6[]
 
-  for _, match, metadata in query:iter_matches(root, 0) do
+  -- TODO: Remove after compatibility with Neovim=0.10 is dropped
+  local opts = { all = true }
+  for _, match, metadata in query:iter_matches(root, 0, nil, nil, opts) do
     for capture_id, nodes in pairs(match) do
       if query.captures[capture_id] == capture then
         metadata = (metadata or {})[capture_id] or {}


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

This PR makes two things:

- `mini.ai` is now aware of matches with multiple matching nodes
- `mini.ai` now parses on it's own the buffer when there's a need to

Some comments:

> `mini.ai` is now aware of matches with multiple matching nodes

This means that for captures like https://github.com/nvim-treesitter/nvim-treesitter-textobjects/blob/fa32a45fdbab9c9c3bda9ecec9b12dddb221b927/queries/lua/textobjects.scm#L12-L17 (present on the `main` branch of nvim-treesitter-textobjects) the behavior before this change is the following

```lua
--   | the cursor is here
--   v 
a(b, c, d)

-- the user configuration looks like
require("mini.ai").setup {
  custom_textobjects = {
    F = require("mini.ai").gen_spec.treesitter { a = "@call.outer", i = "@call.inner" },
  },
}

-- the user does `viF` and only the `d` is visually selected
```

the behavior after the change is the following

```lua
--   | the cursor is here
--   v 
a(b, c, d)

-- the user configuration looks the same

-- the user does `viF` and everything inside of the parenthesis is visually selected
```

> `mini.ai` now parses on it's own the buffer when there's a need to

This means calling `parser:parse(true)` instead of relying on other plugins (or the treesitter builtin highlighter of Neovim) to do it.

We probably don't need to parse the whole buffer, but this is also a configuration setting different enough from `n_lines` to not use it. Also, we may wan't to only parse the (possibly injected) `language_tree` under cursor instead of all of the langue trees (`language_tree:parse`, instead of `parser:parse`). We also probably may want to use the new async parsing capabilities of treesitter by providing a callback as a second argument for `parser:parse()`

I'm opening this PR mostly for discussion and to hear what others think about the topic. I also already had this code implemented in my own config (https://github.com/TheLeoP/nvim-config/blob/1a1d3fef733b59731faecfb854cb00def1f96c6a/lua/plugins/mini.lua#L43-L57), so I may as well see if it's welcomed upstream. I can add tests and update the documentation if the change is deemed acceptable.