### PR TITLE
fix(pick): prevent clamping of `config.width` if there is no border

### DIFF
--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -2285,7 +2285,7 @@ H.picker_compute_win_config = function(win_config, is_for_open)
   if config.border == 'none' then config.border = { '', ' ', '', '', '', ' ', '', '' } end
   -- - Account for border
   config.height = math.max(math.min(config.height, max_height - 2), 1)
-  config.width = math.max(math.min(config.width, max_width - 2), 1)
+  config.width = math.max(math.min(config.width, max_width), 1)
 
   return config
 end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

This PR fixes the issue of the Pick width not matching the width of the editor as shown in the clip below (see right side).

This is a pretty bandaid fix, but I wanted to create this PR first to ask whether you think it's worth it to handle all different border cases, like only having a right border. Or maybe even remove the `math.min` clamping entirely since neovim already handles values larger than the window size.

https://github.com/user-attachments/assets/96baa0fb-ade8-4c51-bd8e-e68458d1b1e3

