### PR TITLE
Fix .dockerignore file to show docker icon instead of git icon

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -930,6 +930,7 @@ H.file_icons = {
 
   -- Supported by `vim.filetype.match` but result in confusing glyph
   ['.prettierignore'] = { glyph = '', hl = 'MiniIconsOrange' },
+  ['.dockerignore']   = { glyph = '󰡨', hl = 'MiniIconsBlue'   },
 }
 
 -- Filetype icons. Keys are filetypes explicitly supported by Neovim core


### PR DESCRIPTION
- [ ] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [ ] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
This pr is to fix #1909 . I can see the file type belonging to the first category but I put it in the third cause it exactly matches the .prettierignore case.