### PR TITLE
feat(pick): Use user's mappings for builtin help picker

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -871,7 +871,6 @@ H.file_icons = {
   ['.gitlab-ci.yml']     = { glyph = '󰮠', hl = 'MiniIconsOrange' },
   ['.gitkeep']           = { glyph = '󰊢', hl = 'MiniIconsRed'    },
   ['.mailmap']           = { glyph = '󰊢', hl = 'MiniIconsCyan'   },
-  ['.npmignore']         = { glyph = '󰒓', hl = 'MiniIconsGrey'   },
   ['.nvmrc']             = { glyph = '󰒓', hl = 'MiniIconsGreen'  },
   ['.xinitrc']           = { glyph = '󰒓', hl = 'MiniIconsBlue'   },
   ['.zshrc']             = { glyph = '󰒓', hl = 'MiniIconsGreen'  },
@@ -929,7 +928,14 @@ H.file_icons = {
   ['tclsh.rc']            = 'tcl',
 
   -- Supported by `vim.filetype.match` but result in confusing glyph
-  ['.prettierignore'] = { glyph = '', hl = 'MiniIconsOrange' },
+  ['.containerignore'] = { glyph = '󰒓', hl = 'MiniIconsGrey' },
+  ['.dockerignore']    = { glyph = '󰡨', hl = 'MiniIconsOrange' },
+  ['.fdignore']        = { glyph = '󰒓', hl = 'MiniIconsYellow' },
+  ['.ignore']          = { glyph = '󰒓', hl = 'MiniIconsGrey' },
+  ['.npmignore']       = { glyph = '󰒓', hl = 'MiniIconsGrey' },
+  ['.prettierignore']  = { glyph = '', hl = 'MiniIconsOrange' },
+  ['.rgignore']        = { glyph = '󰒓', hl = 'MiniIconsYellow' },
+  ['.vscodeignore']    = { glyph = '', hl = 'MiniIconsAzure' },
 }
 
 -- Filetype icons. Keys are filetypes explicitly supported by Neovim core

--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -1460,9 +1460,9 @@ MiniPick.builtin.help = function(local_opts, opts)
 
   --stylua: ignore
   local mappings = {
-    choose_in_split   = '', show_help_in_split   = map_custom('<C-s>', ''),
-    choose_in_vsplit  = '', show_help_in_vsplit  = map_custom('<C-v>', 'vertical '),
-    choose_in_tabpage = '', show_help_in_tabpage = map_custom('<C-t>', 'tab '),
+    choose_in_split   = '', show_help_in_split   = map_custom(MiniPick.config.mappings.choose_in_split, ''),
+    choose_in_vsplit  = '', show_help_in_vsplit  = map_custom(MiniPick.config.mappings.choose_in_vsplit, 'vertical '),
+    choose_in_tabpage = '', show_help_in_tabpage = map_custom(MiniPick.config.mappings.choose_in_tabpage, 'tab '),
   }
 
   local source = { items = tags, name = 'Help', choose = choose, preview = preview }

--- a/tests/test_icons.lua
+++ b/tests/test_icons.lua
@@ -289,6 +289,9 @@ T['get()']['works with "file" category'] = function()
   -- Cached data for basename should not affect full path resolution
   eq(get('file', 'gshadow'), { 'F', 'Comment', true })
   validate('/etc/gshadow', '󰫴', 'MiniIconsCyan', false)
+
+  -- Should override some confusing `vim.filetype.match()` results
+  validate('.dockerignore', '󰡨', 'MiniIconsOrange', false)
 end
 
 T['get()']['respects `config.use_file_extension`'] = function()


### PR DESCRIPTION
This PR aims to improve user experience by using the user's custom mappings for mini.pick's help picker. If users remap their split mappings, then all pickers should respect that.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)