### PR TITLE
fix(completion): ensure doc is a string when normalizing item doc

### DIFF
--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -1896,7 +1896,7 @@ H.normalize_item_doc = function(lsp_item, fallback_info)
 
   -- Extract string content. Treat markdown and plain kinds the same.
   -- Show both `detail` and `documentation` if the first provides new info.
-  detail, doc = detail or '', (type(doc) == 'table' and doc.value or doc) or ''
+  detail, doc = detail or '', type(doc) == 'table' and doc.value or ''
   -- Wrap details in language's code block to (usually) improve highlighting
   -- This approach seems to work in 'hrsh7th/nvim-cmp'
   detail = (H.is_whitespace(detail) or doc:find(detail, 1, true) ~= nil) and '' or (H.wrap_in_codeblock(detail) .. '\n')


### PR DESCRIPTION
Hi echasnovski.

The `doc` variable inside `H.normalize_item_doc` function could be a table in some case, like when `lsp_item.documentation= { kind = "markdown" }` , which it should always be a string, otherwise it will throw an error while calling `doc:find`.
fixed by adjust the `doc` variable assignment statement.

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

I encountered this problem when using mini.completion with [kulala.nvim](https://github.com/mistweaverco/kulala.nvim), this plugin include a kulala LSP:
<img width="1226" height="974" alt="Snipaste_2025-08-06_14-20-28" src="https://github.com/user-attachments/assets/a1eab5de-5092-415c-965b-c43aa4f55e56" />
