### PR TITLE
fix(#1928)/arduino-completion

### DIFF
--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -1815,7 +1815,9 @@ H.get_lsp_edit_range = function(response_data)
   -- Try using all items to find the first one with edit range
   local items = response_data.result.items or response_data.result
   for _, item in pairs(items) do
-    -- Account for `textEdit` can be either `TextEdit` or `InsertReplaceEdit`
+	if type(item) ~= "table" then return end
+    
+	-- Account for `textEdit` can be either `TextEdit` or `InsertReplaceEdit`
     if type(item.textEdit) == 'table' then return item.textEdit.range or item.textEdit.insert end
   end
 end


### PR DESCRIPTION
- [ ] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [ ] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

I created an issue before checking the bug myself. This PR fixes an issue when working with the `arduino-language-server` in which typing anything that isn't a keyword will throw an error message.

[Screencast From 2025-08-07 00-25-19.webm](https://github.com/user-attachments/assets/c9b72d59-5968-4e0c-a376-6ea52cc21695)
