### PR TITLE
fix(ai): exit operator-pending mode if no textobject is found

### DIFF
--- a/lua/mini/ai.lua
+++ b/lua/mini/ai.lua
@@ -1302,6 +1302,9 @@ H.expr_textobject = function(mode, ai_type, opts)
     vis_mode_field = vim.inspect(vis_mode_field == '' and 'v' or vis_mode_field)
   end
 
+  local tobj = MiniAi.find_textobject(ai_type, tobj_id, opts)
+  if tobj == nil then return '<Esc>' end
+
   -- Make expression
   return '<Cmd>lua '
     .. string.format(


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Fixes #1942. This is a naive solution that results in the textobject being searched twice. A better solution would avoid searching it multiple times, but I first wanted to know if this was a desired change and/or if modifying `select_textobject` (to optionally accept the textobject as a parameter) was an option (or if there's a better option) .