### PR TITLE
feat(misc): make `zoom()` return whether zoomed in or out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,12 @@ There are following change types:
 
 - Add `gen_spotter.vimpattern()` that can generate spotter based on Vimscript (not Lua) pattern.
 
+## mini.misc
+
+### Expand
+
+- Update `zoom()` to return whether current buffer is zoomed in.
+
 ## mini.pick
 
 ### Expand

--- a/doc/mini-misc.txt
+++ b/doc/mini-misc.txt
@@ -302,6 +302,8 @@ Parameters ~
 {buf_id} `(number|nil)` Buffer identifier (see |bufnr()|) to be zoomed.
   Default: 0 for current.
 {config} `(table|nil)` Optional config for window (as for |nvim_open_win()|).
+Return ~
+`(boolean)` Whether current buffer is zoomed in.
 
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/lua/mini/misc.lua
+++ b/lua/mini/misc.lua
@@ -589,13 +589,14 @@ end
 ---@param buf_id number|nil Buffer identifier (see |bufnr()|) to be zoomed.
 ---   Default: 0 for current.
 ---@param config table|nil Optional config for window (as for |nvim_open_win()|).
+---@return boolean Whether current buffer is zoomed in.
 MiniMisc.zoom = function(buf_id, config)
   -- Hide
   if H.zoom_winid and vim.api.nvim_win_is_valid(H.zoom_winid) then
     pcall(vim.api.nvim_del_augroup_by_name, 'MiniMiscZoom')
     vim.api.nvim_win_close(H.zoom_winid, true)
     H.zoom_winid = nil
-    return
+    return false
   end
 
   -- Show
@@ -639,6 +640,7 @@ MiniMisc.zoom = function(buf_id, config)
   end
   vim.api.nvim_create_autocmd('VimResized', { group = gr, callback = adjust_config })
   vim.api.nvim_create_autocmd('OptionSet', { group = gr, pattern = 'cmdheight', callback = adjust_config })
+  return true
 end
 
 -- Helper data ================================================================

--- a/tests/test_misc.lua
+++ b/tests/test_misc.lua
@@ -997,4 +997,23 @@ T['zoom()']['can be safely closed manually'] = function()
   expect.error(function() child.cmd_capture('au MiniMiscZoom') end, 'No such group')
 end
 
+T['zoom()']['returns correct state'] = function()
+  child.set_size(5, 30)
+  local zoomed_in = child.lua_get('MiniMisc.zoom()')
+  eq(zoomed_in, true)
+
+  zoomed_in = child.lua_get('MiniMisc.zoom()')
+  eq(zoomed_in, false)
+end
+
+T['zoom()']['returns correct state if closed manually'] = function()
+  child.set_size(5, 30)
+  local zoomed_in = child.lua_get('MiniMisc.zoom()')
+  eq(zoomed_in, true)
+
+  child.cmd('quit')
+  zoomed_in = child.lua_get('MiniMisc.zoom()')
+  eq(zoomed_in, true)
+end
+
 return T


### PR DESCRIPTION
This PR makes `MiniMisc.zoom` return the zoomed state of current buffer: `true` if zoomed in and `false` if zoomed out. This is useful for conditionally applying additional configurations to the window zoomed in. This feature was suggested in <https://github.com/echasnovski/mini.nvim/discussions/1953#discussioncomment-14138773> and also provides a more robust way to check zoomed state compared to that suggested in <https://github.com/echasnovski/mini.nvim/issues/1911#issuecomment-3112985891>. Basic usage:

```lua
local my_zoom = function()
  -- Do nothing if zoomed out.
  if not MiniMisc.zoom() then return end
  vim.wo.winbar = 'my winbar'
  -- ...other configurations
end
vim.keymap.set('n', '<Leader>z', my_zoom, { desc = 'Zoom' })
```

- [x] I have read [CONTRIBUTING.md](https://github.com/echasnovski/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/echasnovski/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
