### PR TITLE
feat(terminal): open floating terminal or run shell commands in a floating terminal

### DIFF
--- a/lua/mini/terminal.lua
+++ b/lua/mini/terminal.lua
@@ -43,7 +43,7 @@ MiniTerm.config = {
   win = {
     height = 0.8,
     width = 0.8,
-    border = 'rounded',
+    border = vim.o.winborder or 'rounded',
   },
 }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

terminal.lua adds a user command called MiniTerm which opens a floating window when there are no arguments present, and when there is an argument (let's say lazygit), it opens that shell command in a floating terminal window.
It also adds the keybind ctrl-q to exit terminal mode