### PR TITLE
feat(files): add MiniFilesBorderFocused hl

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,7 @@ Here is a list of all highlight groups defined inside 'mini.nvim' modules. See d
 
 - 'mini.files':
     - `MiniFilesBorder`
+    - `MiniFilesBorderFocused`
     - `MiniFilesBorderModified`
     - `MiniFilesCursorLine`
     - `MiniFilesDirectory`

--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -86,6 +86,7 @@ more details.
 # Highlight groups ~
 
 - `MiniFilesBorder` - border of regular windows.
+- `MiniFilesBorderFocused` - border of focused window.
 - `MiniFilesBorderModified` - border of windows showing modified buffer.
 - `MiniFilesCursorLine` - cursor line in explorer windows.
 - `MiniFilesDirectory` - text and icon representing directory.

--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -84,6 +84,7 @@
 --- # Highlight groups ~
 ---
 --- - `MiniFilesBorder` - border of regular windows.
+--- - `MiniFilesBorderFocused` - border of focused window.
 --- - `MiniFilesBorderModified` - border of windows showing modified buffer.
 --- - `MiniFilesCursorLine` - cursor line in explorer windows.
 --- - `MiniFilesDirectory` - text and icon representing directory.
@@ -1329,6 +1330,7 @@ H.create_default_hl = function()
   end
 
   hi('MiniFilesBorder',         { link = 'FloatBorder' })
+  hi('MiniFilesBorderFocused',  { link = 'FloatBorder' })
   hi('MiniFilesBorderModified', { link = 'DiagnosticFloatingWarn' })
   hi('MiniFilesCursorLine',     { link = 'CursorLine' })
   hi('MiniFilesDirectory',      { link = 'Directory'   })
@@ -2453,6 +2455,11 @@ end
 H.window_focus = function(win_id)
   vim.api.nvim_set_current_win(win_id)
   H.window_update_highlight(win_id, 'FloatTitle', 'MiniFilesTitleFocused')
+
+  local buf_id = vim.api.nvim_win_get_buf(win_id)
+  if not H.is_modified_buffer(buf_id) then
+    H.window_update_highlight(win_id, 'FloatBorder', 'MiniFilesBorderFocused')
+  end
 end
 
 H.window_close = function(win_id)

--- a/tests/test_files.lua
+++ b/tests/test_files.lua
@@ -222,6 +222,7 @@ T['setup()']['creates side effects'] = function()
   local validate_hl_group = function(name, ref) expect.match(child.cmd_capture('hi ' .. name), ref) end
 
   validate_hl_group('MiniFilesBorder', 'links to FloatBorder')
+  validate_hl_group('MiniFilesBorderFocused', 'links to FloatBorder')
   validate_hl_group('MiniFilesBorderModified', 'links to DiagnosticFloatingWarn')
   validate_hl_group('MiniFilesCursorLine', 'links to CursorLine')
   validate_hl_group('MiniFilesDirectory', 'links to Directory')
@@ -2463,6 +2464,7 @@ T['Windows']['uses correct UI highlight groups'] = function()
     -- Make sure entry is match in full
     local base_pattern = from_hl .. ':' .. to_hl
     local is_matched = winhl:find(base_pattern .. ',') ~= nil or winhl:find(base_pattern .. '$') ~= nil
+    if not is_matched then error('Pattern "' .. base_pattern .. '" not found in "' .. winhl .. '"') end
     eq(is_matched, true)
   end
 
@@ -2476,14 +2478,14 @@ T['Windows']['uses correct UI highlight groups'] = function()
   validate_winhl_match(win_id_1, 'FloatTitle', 'MiniFilesTitle')
   validate_winhl_match(win_id_1, 'CursorLine', 'MiniFilesCursorLine')
   validate_winhl_match(win_id_2, 'NormalFloat', 'MiniFilesNormal')
-  validate_winhl_match(win_id_2, 'FloatBorder', 'MiniFilesBorder')
+  validate_winhl_match(win_id_2, 'FloatBorder', 'MiniFilesBorderFocused')
   validate_winhl_match(win_id_2, 'FloatTitle', 'MiniFilesTitleFocused')
   validate_winhl_match(win_id_2, 'CursorLine', 'MiniFilesCursorLine')
 
   -- Simply going in Insert mode should not add "modified"
   type_keys('i')
   validate_winhl_match(win_id_1, 'FloatBorder', 'MiniFilesBorder')
-  validate_winhl_match(win_id_2, 'FloatBorder', 'MiniFilesBorder')
+  validate_winhl_match(win_id_2, 'FloatBorder', 'MiniFilesBorderFocused')
 
   type_keys('x')
   validate_winhl_match(win_id_1, 'FloatBorder', 'MiniFilesBorder')


### PR DESCRIPTION
Introduce new `MiniFilesBorderFocused` highlight for the active MiniFiles window so it can be themed distinctly. 
`MiniFilesBorderModified` takes precedence over "Focused" when the buffer is dirty.

Here's an example with catppuccin theme and some custom hl definitions
<img width="1087" height="717" alt="Screenshot 2025-10-13 at 14 11 22" src="https://github.com/user-attachments/assets/e0da6f11-b894-4bf4-a5ad-281eb411e0fe" />


- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

