### PR TITLE
refactor(ALL): use `vim.uv` instead of `vim.loop`

### DIFF
--- a/colors/randomhue.lua
+++ b/colors/randomhue.lua
@@ -2,7 +2,7 @@ local hues = require('mini.hues')
 
 -- Generate random config with initialized random seed (otherwise it won't be
 -- random during startup)
-math.randomseed(vim.loop.hrtime())
+math.randomseed(vim.uv.hrtime())
 local base_colors = hues.gen_random_base_colors()
 
 hues.setup({

--- a/doc/mini-hues.txt
+++ b/doc/mini-hues.txt
@@ -400,7 +400,7 @@ Notes:
   proper random generation. For example: >
 
   local hues = require('mini.hues')
-  math.randomseed(vim.loop.hrtime())
+  math.randomseed(vim.uv.hrtime())
   hues.setup(hues.gen_random_base_colors())
 
 Parameters ~

--- a/doc/mini-snippets.txt
+++ b/doc/mini-snippets.txt
@@ -497,7 +497,7 @@ Use |ModeChanged| and |MiniSnippets-events| events: >lua
 Create environment variables and `config.expand.insert` wrapper: >lua
 
   -- Use evnironment variables with value is same for all snippet sessions
-  vim.loop.os_setenv('USERNAME', 'user')
+  vim.uv.os_setenv('USERNAME', 'user')
 
   -- Compute custom lookup for variables with dynamic values
   local insert_with_lookup = function(snippet)

--- a/doc/mini-starter.txt
+++ b/doc/mini-starter.txt
@@ -133,7 +133,7 @@ for disabling module's functionality is left to user. See
   }
 
   local footer_n_seconds = (function()
-    local timer = vim.loop.new_timer()
+    local timer = vim.uv.new_timer()
     local n_seconds = 0
     timer:start(0, 1000, vim.schedule_wrap(function()
       if vim.bo.filetype ~= 'ministarter' then

--- a/doc/mini-test.txt
+++ b/doc/mini-test.txt
@@ -804,7 +804,7 @@ Fields ~
 {highlight} `(table)` Redirection table for |vim.highlight|.
 {hl} `(table)` Redirection table for |vim.hl|.
 {json} `(table)` Redirection table for `vim.json`.
-{loop} `(table)` Redirection table for |vim.loop|.
+{loop} `(table)` Redirection table for |vim.uv|.
 {lsp} `(table)` Redirection table for `vim.lsp` (|lsp-core|).
 {mpack} `(table)` Redirection table for |vim.mpack|.
 {spell} `(table)` Redirection table for |vim.spell|.

--- a/lua/mini/align.lua
+++ b/lua/mini/align.lua
@@ -800,7 +800,7 @@ MiniAlign.align_user = function(mode)
         local msg = string.format('Modifier %s should be properly callable. Reason: %s', vim.inspect(id), out)
         H.echo({ { msg, 'WarningMsg' } }, true)
         vim.cmd('redraw')
-        vim.loop.sleep(500)
+        vim.uv.sleep(500)
       end
     end
 

--- a/lua/mini/animate.lua
+++ b/lua/mini/animate.lua
@@ -581,7 +581,7 @@ MiniAnimate.animate = function(step_action, step_timing, opts)
   opts = vim.tbl_deep_extend('force', { max_steps = 10000000 }, opts or {})
 
   local step, max_steps = 0, opts.max_steps
-  local timer, wait_time = vim.loop.new_timer(), 0
+  local timer, wait_time = vim.uv.new_timer(), 0
 
   local draw_step
   draw_step = vim.schedule_wrap(function()

--- a/lua/mini/bracketed.lua
+++ b/lua/mini/bracketed.lua
@@ -1659,8 +1659,8 @@ H.get_file_data = function()
   local dir_path = cur_buf_path ~= '' and vim.fn.fnamemodify(cur_buf_path, ':p:h') or vim.fn.getcwd()
 
   -- Compute sorted array of all files in target directory
-  local dir_handle = vim.loop.fs_scandir(dir_path)
-  local files_stream = function() return vim.loop.fs_scandir_next(dir_handle) end
+  local dir_handle = vim.uv.fs_scandir(dir_path)
+  local files_stream = function() return vim.uv.fs_scandir_next(dir_handle) end
 
   local files = {}
   for basename, fs_type in files_stream do

--- a/lua/mini/clue.lua
+++ b/lua/mini/clue.lua
@@ -1154,7 +1154,7 @@ H.state = {
   -- Array of raw keys
   query = {},
   clues = {},
-  timer = vim.loop.new_timer(),
+  timer = vim.uv.new_timer(),
   buf_id = nil,
   win_id = nil,
   is_after_postkeys = false,
@@ -1182,7 +1182,7 @@ H.keys = {
 
 -- Timers
 H.timers = {
-  getcharstr = vim.loop.new_timer(),
+  getcharstr = vim.uv.new_timer(),
 }
 
 -- Undo autocommand to be created for several operator tweaks

--- a/lua/mini/colors.lua
+++ b/lua/mini/colors.lua
@@ -1756,7 +1756,7 @@ H.animate_single_transition = function(from_cs, to_cs, after_action, opts)
 
   -- Start animation
   local cur_step = 1
-  local timer = vim.loop.new_timer()
+  local timer = vim.uv.new_timer()
 
   local apply_step
   apply_step = vim.schedule_wrap(function()

--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -708,7 +708,7 @@ H.completion = {
   force = false,
   source = nil,
   text_changed_id = 0,
-  timer = vim.loop.new_timer(),
+  timer = vim.uv.new_timer(),
   lsp = { id = 0, status = nil, is_incomplete = false, result = nil, resolved = {}, cancel_fun = nil, context = nil },
   init_base = { lnum = nil, col = nil, length = nil },
 }
@@ -718,7 +718,7 @@ H.info = {
   bufnr = nil,
   event = nil,
   id = 0,
-  timer = vim.loop.new_timer(),
+  timer = vim.uv.new_timer(),
   win_id = nil,
   lsp = { id = 0, status = nil, result = nil, cancel_fun = nil },
 }
@@ -727,7 +727,7 @@ H.info = {
 H.signature = {
   bufnr = nil,
   text = nil,
-  timer = vim.loop.new_timer(),
+  timer = vim.uv.new_timer(),
   win_id = nil,
   lsp = { id = 0, status = nil, result = nil, cancel_fun = nil },
 }

--- a/lua/mini/cursorword.lua
+++ b/lua/mini/cursorword.lua
@@ -121,7 +121,7 @@ MiniCursorword.config = {
 H.default_config = vim.deepcopy(MiniCursorword.config)
 
 -- Delay timer
-H.timer = vim.loop.new_timer()
+H.timer = vim.uv.new_timer()
 
 -- Information about last match highlighting (stored *per window*):
 -- - Key: windows' unique buffer identifiers.

--- a/lua/mini/deps.lua
+++ b/lua/mini/deps.lua
@@ -1200,11 +1200,11 @@ H.get_plugin_path = function(name)
 
   -- First check for the most common case of name present in 'pack/deps/opt'
   local opt_path = string.format('%s/pack/deps/opt/%s', package_path, name)
-  if vim.loop.fs_stat(opt_path) ~= nil then return opt_path, true end
+  if vim.uv.fs_stat(opt_path) ~= nil then return opt_path, true end
 
   -- Allow processing 'pack/deps/start'
   local start_path = string.format('%s/pack/deps/start/%s', package_path, name)
-  if vim.loop.fs_stat(start_path) ~= nil then return start_path, true end
+  if vim.uv.fs_stat(start_path) ~= nil then return start_path, true end
 
   -- Use 'opt' directory by default
   return opt_path, false
@@ -1484,9 +1484,9 @@ H.cli_run = function(jobs)
     local job = jobs[id_started]
     local command, cwd, exit_msg = job.command or {}, job.cwd, job.exit_msg
 
-    -- Prepare data for `vim.loop.spawn`
+    -- Prepare data for `vim.uv.spawn`
     local executable, args = command[1], vim.list_slice(command, 2, #command)
-    local process, stdout, stderr = nil, vim.loop.new_pipe(), vim.loop.new_pipe()
+    local process, stdout, stderr = nil, vim.uv.new_pipe(), vim.uv.new_pipe()
 
     -- - Unset special `GIT_xxx` variables that can affect `git` commands
     local env_map = vim.fn.environ()
@@ -1522,7 +1522,7 @@ H.cli_run = function(jobs)
       run_next()
     end
 
-    process = vim.loop.spawn(executable, spawn_opts, on_exit)
+    process = vim.uv.spawn(executable, spawn_opts, on_exit)
     H.cli_read_stream(stdout, job.out)
     H.cli_read_stream(stderr, job.err)
     vim.defer_fn(function()
@@ -1562,7 +1562,7 @@ H.schedule_finish = function()
 end
 
 H.finish = function()
-  local timer, step_delay = vim.loop.new_timer(), 1
+  local timer, step_delay = vim.uv.new_timer(), 1
   local f = nil
   f = vim.schedule_wrap(function()
     local callback = H.cache.later_callback_queue[1]
@@ -1619,7 +1619,7 @@ end
 
 H.get_timestamp = function() return vim.fn.strftime('%Y-%m-%d %H:%M:%S') end
 
-H.get_n_threads = function() return math.floor(0.8 * #(vim.loop.cpu_info() or {})) end
+H.get_n_threads = function() return math.floor(0.8 * #(vim.uv.cpu_info() or {})) end
 
 H.full_path = function(path) return (vim.fn.fnamemodify(path, ':p'):gsub('\\', '/'):gsub('/+', '/'):gsub('(.)/$', '%1')) end
 

--- a/lua/mini/doc.lua
+++ b/lua/mini/doc.lua
@@ -833,7 +833,7 @@ H.default_input = function()
 end
 
 H.default_output = function()
-  local cur_dir = vim.fn.fnamemodify(vim.loop.cwd(), ':t:r')
+  local cur_dir = vim.fn.fnamemodify(vim.uv.cwd(), ':t:r')
   return ('doc/%s.txt'):format(cur_dir)
 end
 

--- a/lua/mini/extra.lua
+++ b/lua/mini/extra.lua
@@ -1624,7 +1624,7 @@ H.ns_id = {
 H.cache = {}
 
 -- File system information
-H.is_windows = vim.loop.os_uname().sysname == 'Windows_NT'
+H.is_windows = vim.uv.os_uname().sysname == 'Windows_NT'
 
 -- Helper functionality =======================================================
 -- Settings -------------------------------------------------------------------
@@ -2106,9 +2106,9 @@ end
 H.cli_run = function(command, stdout_hook)
   stdout_hook = stdout_hook or function() end
   local executable, args = command[1], vim.list_slice(command, 2, #command)
-  local process, stdout, stderr = nil, vim.loop.new_pipe(), vim.loop.new_pipe()
+  local process, stdout, stderr = nil, vim.uv.new_pipe(), vim.uv.new_pipe()
   local spawn_opts = { args = args, stdio = { nil, stdout, stderr } }
-  process = vim.loop.spawn(executable, spawn_opts, function() process:close() end)
+  process = vim.uv.spawn(executable, spawn_opts, function() process:close() end)
 
   H.cli_read_stream(stdout, stdout_hook)
   H.cli_read_stream(stderr, function(lines)

--- a/lua/mini/hipatterns.lua
+++ b/lua/mini/hipatterns.lua
@@ -648,8 +648,8 @@ end
 H.default_config = vim.deepcopy(MiniHipatterns.config)
 
 -- Timers
-H.timer_debounce = vim.loop.new_timer()
-H.timer_view = vim.loop.new_timer()
+H.timer_debounce = vim.uv.new_timer()
+H.timer_view = vim.uv.new_timer()
 
 -- Namespaces per highlighter name
 H.ns_id = {}

--- a/lua/mini/hues.lua
+++ b/lua/mini/hues.lua
@@ -1579,7 +1579,7 @@ MiniHues.get_palette = function() return vim.deepcopy(H.palette) end
 ---   proper random generation. For example: >
 ---
 ---   local hues = require('mini.hues')
----   math.randomseed(vim.loop.hrtime())
+---   math.randomseed(vim.uv.hrtime())
 ---   hues.setup(hues.gen_random_base_colors())
 ---
 ---@param opts table|nil Options. Possible values:

--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -2164,7 +2164,7 @@ H.set_buf_name = function(buf_id, name) vim.api.nvim_buf_set_name(buf_id, 'minii
 H.notify = function(msg, level_name) vim.notify('(mini.icons) ' .. msg, vim.log.levels[level_name]) end
 
 H.fs_basename = function(x) return vim.fn.fnamemodify(x:sub(-1, -1) == '/' and x:sub(1, -2) or x, ':t') end
-if vim.loop.os_uname().sysname == 'Windows_NT' then
+if vim.uv.os_uname().sysname == 'Windows_NT' then
   H.fs_basename = function(x)
     local last = x:sub(-1, -1)
     return vim.fn.fnamemodify((last == '/' or last == '\\') and x:sub(1, -2) or x, ':t')

--- a/lua/mini/indentscope.lua
+++ b/lua/mini/indentscope.lua
@@ -551,7 +551,7 @@ H.default_config = vim.deepcopy(MiniIndentscope.config)
 H.ns_id = vim.api.nvim_create_namespace('MiniIndentscope')
 
 -- Timer for doing animation
-H.timer = vim.loop.new_timer()
+H.timer = vim.uv.new_timer()
 
 -- Table with current relevalnt data:
 -- - `event_id` - counter for events.

--- a/lua/mini/jump.lua
+++ b/lua/mini/jump.lua
@@ -303,7 +303,7 @@ H.cache = {
 }
 
 -- Timers for different delay-related functionalities
-H.timers = { highlight = vim.loop.new_timer(), idle_stop = vim.loop.new_timer() }
+H.timers = { highlight = vim.uv.new_timer(), idle_stop = vim.uv.new_timer() }
 
 -- Information about last match highlighting (stored *per window*):
 -- - Key: windows' unique buffer identifiers.

--- a/lua/mini/keymap.lua
+++ b/lua/mini/keymap.lua
@@ -521,7 +521,7 @@ MiniKeymap.map_combo = function(mode, lhs, action, opts)
   local delay = opts.delay or 200
   if not (type(delay) == 'number' and delay > 0) then H.error('`opts.delay` should be a positive number') end
 
-  local hrtime, get_key = vim.loop.hrtime, H.combo_get_key
+  local hrtime, get_key = vim.uv.hrtime, H.combo_get_key
   local i, last_time, n_seq = 0, hrtime(), #seq
   local delay_ns = 1000000 * delay
   -- NOTE: It is possible to track mode in 'ModeChanged' event and use it for

--- a/lua/mini/misc.lua
+++ b/lua/mini/misc.lua
@@ -88,9 +88,9 @@ MiniMisc.bench_time = function(f, n, ...)
   n = n or 1
   local durations, output = {}, nil
   for _ = 1, n do
-    local start_time = vim.loop.hrtime()
+    local start_time = vim.uv.hrtime()
     output = f(...)
-    local end_time = vim.loop.hrtime()
+    local end_time = vim.uv.hrtime()
     table.insert(durations, 0.000000001 * (end_time - start_time))
   end
 

--- a/lua/mini/notify.lua
+++ b/lua/mini/notify.lua
@@ -897,8 +897,8 @@ H.fit_to_width = function(text, width)
 end
 
 H.get_timestamp = function()
-  -- This is more acceptable for `vim.fn.strftime()` than `vim.loop.hrtime()`
-  local seconds, microseconds = vim.loop.gettimeofday()
+  -- This is more acceptable for `vim.fn.strftime()` than `vim.uv.hrtime()`
+  local seconds, microseconds = vim.uv.gettimeofday()
   return seconds + 0.000001 * microseconds
 end
 

--- a/lua/mini/snippets.lua
+++ b/lua/mini/snippets.lua
@@ -492,7 +492,7 @@
 --- Create environment variables and `config.expand.insert` wrapper: >lua
 ---
 ---   -- Use evnironment variables with value is same for all snippet sessions
----   vim.loop.os_setenv('USERNAME', 'user')
+---   vim.uv.os_setenv('USERNAME', 'user')
 ---
 ---   -- Compute custom lookup for variables with dynamic values
 ---   local insert_with_lookup = function(snippet)
@@ -1834,7 +1834,7 @@ H.parse_normalize = function(node_arr, opts)
     has_final_tabstop = has_final_tabstop or n.tabstop == '0'
   end
   -- - Ensure proper random random variables
-  math.randomseed(vim.loop.hrtime())
+  math.randomseed(vim.uv.hrtime())
   H.nodes_traverse(node_arr, normalize)
 
   -- Possibly append final tabstop as a regular normalized tabstop
@@ -2028,7 +2028,7 @@ H.parse_eval_var = function(var, lookup)
   local value
   if H.var_evaluators[var] ~= nil then value = H.var_evaluators[var]() end
   -- - Fall back to environment variable or `-1` to not evaluate twice
-  if value == nil then value = vim.loop.os_getenv(var) or -1 end
+  if value == nil then value = vim.uv.os_getenv(var) or -1 end
 
   -- Skip caching random variables (to allow several different in one snippet)
   if not (var == 'RANDOM' or var == 'RANDOM_HEX' or var == 'UUID') then lookup[var] = value end

--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -130,7 +130,7 @@
 ---   }
 ---
 ---   local footer_n_seconds = (function()
----     local timer = vim.loop.new_timer()
+---     local timer = vim.uv.new_timer()
 ---     local n_seconds = 0
 ---     timer:start(0, 1000, vim.schedule_wrap(function()
 ---       if vim.bo.filetype ~= 'ministarter' then
@@ -506,7 +506,7 @@ MiniStarter.sections.recent_files = function(n, current_dir, show_path)
 
   return function()
     local section = string.format('Recent files%s', current_dir and ' (current directory)' or '')
-    local sep = vim.loop.os_uname().sysname == 'Windows_NT' and '\\' or '/'
+    local sep = vim.uv.os_uname().sysname == 'Windows_NT' and '\\' or '/'
     local cwd = vim.fn.getcwd() .. sep
 
     local files = {}
@@ -987,7 +987,7 @@ H.default_header = function()
   -- [04:00, 12:00) - morning, [12:00, 20:00) - day, [20:00, 04:00) - evening
   local part_id = math.floor((hour + 4) / 8) + 1
   local day_part = ({ 'evening', 'morning', 'afternoon', 'evening' })[part_id]
-  local username = vim.loop.os_get_passwd()['username'] or 'USERNAME'
+  local username = vim.uv.os_get_passwd()['username'] or 'USERNAME'
 
   return ('Good %s, %s'):format(day_part, username)
 end

--- a/lua/mini/test.lua
+++ b/lua/mini/test.lua
@@ -903,7 +903,7 @@ MiniTest.gen_reporter.buffer = function(opts)
     H.buffer_reporter.set_lines(buf_id, lines, -n_replace - 1, -1)
 
     -- Throttle redraw to reduce flicker
-    local cur_time = vim.loop.hrtime()
+    local cur_time = vim.uv.hrtime()
     local is_enough_time_passed = (cur_time - latest_draw_time) > opts.throttle_delay * 1000000
     if is_enough_time_passed or force then
       vim.cmd('redraw')
@@ -1117,7 +1117,7 @@ MiniTest.new_child_neovim = function()
     -- Using 'jobstart' for creating a job is crucial for getting this to work
     -- in Github Actions. Other approaches:
     -- - Using `{ pty = true }` seems crucial to make this work on GitHub CI.
-    -- - Using `vim.loop.spawn()` is doable, but has some issues:
+    -- - Using `vim.uv.spawn()` is doable, but has some issues:
     --     - https://github.com/neovim/neovim/issues/21630
     --     - https://github.com/neovim/neovim/issues/21886
     job.id = vim.fn.jobstart(full_args)
@@ -1126,7 +1126,7 @@ MiniTest.new_child_neovim = function()
     local connected, i, max_tries = nil, 0, math.floor(opts.connection_timeout / step)
     repeat
       i = i + 1
-      vim.loop.sleep(step)
+      vim.uv.sleep(step)
       connected, job.channel = pcall(vim.fn.sockconnect, 'pipe', job.address, { rpc = true })
     until connected or i >= max_tries
 
@@ -1285,7 +1285,7 @@ MiniTest.new_child_neovim = function()
       end
 
       -- Possibly wait
-      if has_wait and wait > 0 then vim.loop.sleep(wait) end
+      if has_wait and wait > 0 then vim.uv.sleep(wait) end
     end
   end
 
@@ -1448,7 +1448,7 @@ end
 ---@field highlight table Redirection table for |vim.highlight|.
 ---@field hl table Redirection table for |vim.hl|.
 ---@field json table Redirection table for `vim.json`.
----@field loop table Redirection table for |vim.loop|.
+---@field loop table Redirection table for |vim.uv|.
 ---@field lsp table Redirection table for `vim.lsp` (|lsp-core|).
 ---@field mpack table Redirection table for |vim.mpack|.
 ---@field spell table Redirection table for |vim.spell|.

--- a/lua/mini/visits.lua
+++ b/lua/mini/visits.lua
@@ -1170,7 +1170,7 @@ H.default_config = MiniVisits.config
 
 -- Various timers
 H.timers = {
-  track = vim.loop.new_timer(),
+  track = vim.uv.new_timer(),
 }
 
 -- Current visit index
@@ -1190,7 +1190,7 @@ H.cache = {
 }
 
 -- File system information
-H.is_windows = vim.loop.os_uname().sysname == 'Windows_NT'
+H.is_windows = vim.uv.os_uname().sysname == 'Windows_NT'
 
 -- Helper functionality =======================================================
 -- Settings -------------------------------------------------------------------

--- a/scripts/init-deps-example.lua
+++ b/scripts/init-deps-example.lua
@@ -1,7 +1,7 @@
 -- Clone 'mini.nvim' manually in a way that it gets managed by 'mini.deps'
 local path_package = vim.fn.stdpath('data') .. '/site/'
 local mini_path = path_package .. 'pack/deps/start/mini.nvim'
-if not vim.loop.fs_stat(mini_path) then
+if not vim.uv.fs_stat(mini_path) then
   vim.cmd('echo "Installing `mini.nvim`" | redraw')
   local clone_cmd = { 'git', 'clone', '--filter=blob:none', 'https://github.com/nvim-mini/mini.nvim', mini_path }
   vim.fn.system(clone_cmd)

--- a/scripts/lintcommit.lua
+++ b/scripts/lintcommit.lua
@@ -18,7 +18,7 @@ end
 local validate_subject = function(line)
   -- Possibly allow starting with 'fixup' to disable commit linting
   if vim.startswith(line, 'fixup') then
-    local is_strict = vim.loop.os_getenv('LINTCOMMIT_STRICT') ~= nil
+    local is_strict = vim.uv.os_getenv('LINTCOMMIT_STRICT') ~= nil
     local msg = is_strict and 'No "fixup" commits are allowed.' or ''
     return not is_strict, msg
   end
@@ -124,7 +124,7 @@ local validate_commit_msg = function(lines)
   local is_valid, err_msg
 
   -- If not in strict context, ignore lines which will be later cleaned up
-  local is_strict = vim.loop.os_getenv('LINTCOMMIT_STRICT') ~= nil
+  local is_strict = vim.uv.os_getenv('LINTCOMMIT_STRICT') ~= nil
   if not is_strict then lines = remove_cleanup_lines(lines) end
 
   -- Allow all lines to be empty to abort committing
@@ -296,7 +296,7 @@ local test_cases = {
 
 _G.test_cases_failed = {}
 
-vim.loop.os_unsetenv('LINTCOMMIT_STRICT')
+vim.uv.os_unsetenv('LINTCOMMIT_STRICT')
 for message, expected in pairs(test_cases) do
   local lines = vim.split(message, '\n')
   local is_valid = validate_commit_msg(lines)
@@ -305,7 +305,7 @@ for message, expected in pairs(test_cases) do
   end
 end
 
-vim.loop.os_setenv('LINTCOMMIT_STRICT', 'true')
+vim.uv.os_setenv('LINTCOMMIT_STRICT', 'true')
 local strict_test_cases = {
   -- Fixup commit type is not allowed
   ['fixup'] = false,
@@ -340,4 +340,4 @@ for message, expected in pairs(strict_test_cases) do
 end
 
 -- Cleanup
-vim.loop.os_unsetenv('LINTCOMMIT_STRICT')
+vim.uv.os_unsetenv('LINTCOMMIT_STRICT')

--- a/tests/dir-deps/mocks/spawn.lua
+++ b/tests/dir-deps/mocks/spawn.lua
@@ -17,11 +17,11 @@ end
 -- Define object containing the queue with mocking stdio data.
 -- Each element is a table with `out` and `err` fields, both can be `nil`,
 -- `string`, or `string[]`. **Heavy** assumptions about how `new_pipe` is used:
--- - It is called twice before each `vim.loop.spawn`.
+-- - It is called twice before each `vim.uv.spawn`.
 -- - It is first called for `stdout`, then for `stderr`.
 _G.stdio_queue = {}
 local io_field = 'out'
-vim.loop.new_pipe = function()
+vim.uv.new_pipe = function()
   local cur_process_id, cur_io_field = process_id, io_field
   local cur_feed = (_G.stdio_queue[cur_process_id] or {})[cur_io_field]
   if type(cur_feed) ~= 'table' then cur_feed = { cur_feed } end
@@ -48,7 +48,7 @@ end
 -- - <exit_code> `(number|nil)` - exit code. Default: 0.
 _G.process_mock_data = {}
 _G.spawn_log = {}
-vim.loop.spawn = function(path, options, on_exit)
+vim.uv.spawn = function(path, options, on_exit)
   local options_without_callables = vim.deepcopy(options) or {}
   options_without_callables.stdio = nil
   table.insert(_G.spawn_log, { executable = path, options = options_without_callables })
@@ -63,10 +63,10 @@ vim.loop.spawn = function(path, options, on_exit)
   return new_process(pid), pid
 end
 
-vim.loop.process_kill = function(process) table.insert(_G.process_log, 'Process ' .. process.pid .. ' was killed.') end
+vim.uv.process_kill = function(process) table.insert(_G.process_log, 'Process ' .. process.pid .. ' was killed.') end
 
 _G.n_cpu_info = 4
-vim.loop.cpu_info = function()
+vim.uv.cpu_info = function()
   local res = {}
   for i = 1, _G.n_cpu_info do
     res[i] = { model = 'A Very High End CPU' }

--- a/tests/dir-diff/mocks/spawn.lua
+++ b/tests/dir-diff/mocks/spawn.lua
@@ -12,7 +12,7 @@ end
 -- - Element 2 is the feed of the pipe. Can be `nil`, `string`, `string[]`.
 _G.stdio_queue = {}
 local process_pipe_indexes = {}
-vim.loop.new_pipe = function()
+vim.uv.new_pipe = function()
   local cur_process_id = process_id
   local process_pipe_data = _G.stdio_queue[cur_process_id] or {}
 
@@ -51,7 +51,7 @@ end
 -- - <exit_code> `(number|nil)` - exit code. Default: 0.
 _G.process_mock_data = {}
 _G.spawn_log = {}
-vim.loop.spawn = function(path, options, on_exit)
+vim.uv.spawn = function(path, options, on_exit)
   local options_without_callables = vim.deepcopy(options) or {}
   options_without_callables.stdio = nil
   table.insert(_G.spawn_log, { executable = path, options = options_without_callables })

--- a/tests/dir-doc/helpers.lua
+++ b/tests/dir-doc/helpers.lua
@@ -2,7 +2,7 @@ H = {}
 
 --- Remove (possibly not empty) directory
 _G.remove_dir = function(path)
-  local fs = vim.loop.fs_scandir(path)
+  local fs = vim.uv.fs_scandir(path)
   if not fs then
     vim.notify([[Couldn't open directory ]] .. path)
     return
@@ -10,13 +10,13 @@ _G.remove_dir = function(path)
 
   local path_sep = package.config:sub(1, 1)
   while true do
-    local f_name, _ = vim.loop.fs_scandir_next(fs)
+    local f_name, _ = vim.uv.fs_scandir_next(fs)
     if f_name == nil then break end
     local p = ('%s%s%s'):format(path, path_sep, f_name)
-    vim.loop.fs_unlink(p)
+    vim.uv.fs_unlink(p)
   end
 
-  vim.loop.fs_rmdir(path)
+  vim.uv.fs_rmdir(path)
 end
 
 _G.validate_doc_structure = function(x)

--- a/tests/dir-extra/mocks/spawn.lua
+++ b/tests/dir-extra/mocks/spawn.lua
@@ -17,9 +17,9 @@ end
 -- arrays as source. Each feed's element should be either string (for usable
 -- data) or a table with `err` field (for error).
 local stream_counts = {}
-vim.loop.new_pipe = function()
+vim.uv.new_pipe = function()
   -- NOTE: Use `_G.stream_type_queue` to determine which stream type to create
-  -- (for log purposes). This is to account for `vim.loop.spawn` creating
+  -- (for log purposes). This is to account for `vim.uv.spawn` creating
   -- different sets of streams. Assume 'stdout' by default.
   if _G.stream_type_queue == nil or #_G.stream_type_queue == 0 then _G.stream_type_queue = { 'stdout' } end
   local stream_type = _G.stream_type_queue[1]
@@ -45,7 +45,7 @@ vim.loop.new_pipe = function()
 end
 
 _G.spawn_log = {}
-vim.loop.spawn = function(path, options, on_exit)
+vim.uv.spawn = function(path, options, on_exit)
   local options_without_callables = vim.deepcopy(options)
   options_without_callables.stdio = nil
   table.insert(_G.spawn_log, { executable = path, options = options_without_callables })
@@ -57,7 +57,7 @@ vim.loop.spawn = function(path, options, on_exit)
   return new_process(pid), pid
 end
 
-vim.loop.process_kill = function(process)
+vim.uv.process_kill = function(process)
   process._is_active_indicator = false
   table.insert(_G.process_log, 'Process ' .. process.pid .. ' was killed.')
 end

--- a/tests/dir-git/mocks/spawn.lua
+++ b/tests/dir-git/mocks/spawn.lua
@@ -19,7 +19,7 @@ end
 -- - Element 2 is the feed of the pipe. Can be `nil`, `string`, `string[]`.
 _G.stdio_queue = {}
 local process_pipe_indexes = {}
-vim.loop.new_pipe = function()
+vim.uv.new_pipe = function()
   local cur_process_id = process_id
   local process_pipe_data = _G.stdio_queue[cur_process_id] or {}
 
@@ -58,7 +58,7 @@ end
 -- - <exit_code> `(number|nil)` - exit code. Default: 0.
 _G.process_mock_data = {}
 _G.spawn_log = {}
-vim.loop.spawn = function(path, options, on_exit)
+vim.uv.spawn = function(path, options, on_exit)
   local options_without_callables = vim.deepcopy(options) or {}
   options_without_callables.stdio = nil
   table.insert(_G.spawn_log, { executable = path, options = options_without_callables })

--- a/tests/dir-pick/mocks/spawn.lua
+++ b/tests/dir-pick/mocks/spawn.lua
@@ -16,7 +16,7 @@ end
 -- Mock `stdout` by using global `_G.stdout_data_feed` array as source.
 -- Each feed's element should be either string (for usable data) or a table
 -- with `err` field (for error).
-vim.loop.new_pipe = function()
+vim.uv.new_pipe = function()
   n_stdout = n_stdout + 1
   local cur_stdout_id = 'Stdout_' .. n_stdout
 
@@ -40,7 +40,7 @@ vim.loop.new_pipe = function()
 end
 
 _G.spawn_log = {}
-vim.loop.spawn = function(path, options, on_exit)
+vim.uv.spawn = function(path, options, on_exit)
   local options_without_callables = vim.deepcopy(options)
   options_without_callables.stdio = nil
   table.insert(_G.spawn_log, { executable = path, options = options_without_callables })
@@ -52,7 +52,7 @@ vim.loop.spawn = function(path, options, on_exit)
   return new_process(pid), pid
 end
 
-vim.loop.process_kill = function(process)
+vim.uv.process_kill = function(process)
   process._is_active_indicator = false
   table.insert(_G.process_log, 'Process ' .. process.pid .. ' was killed.')
 end

--- a/tests/helpers.lua
+++ b/tests/helpers.lua
@@ -226,7 +226,7 @@ Helpers.sleep = function(ms, child, skip_slow)
   if skip_slow then
     Helpers.skip_if_slow('Skip because state checks after sleep are hard to make robust in slow context')
   end
-  vim.loop.sleep(math.max(ms, 1))
+  vim.uv.sleep(math.max(ms, 1))
   if child ~= nil then child.poke_eventloop() end
 end
 

--- a/tests/test_align.lua
+++ b/tests/test_align.lua
@@ -1374,9 +1374,9 @@ T['Align']['does not stop on error during modifier execution'] = function()
   set_cursor(1, 0)
 
   -- Error in modifier execution should lead to a pause to make message visible
-  local before_time = vim.loop.hrtime()
+  local before_time = vim.uv.hrtime()
   type_keys('Vj', 'ga', 'e')
-  local duration = 0.000001 * (vim.loop.hrtime() - before_time)
+  local duration = 0.000001 * (vim.uv.hrtime() - before_time)
   eq(error_message_force_delay <= duration and duration <= error_message_force_delay + 2 * small_time, true)
   expect.match(get_latest_message(), '^%(mini.align%) Modifier "e" should be properly callable%. Reason:')
 end

--- a/tests/test_clue.lua
+++ b/tests/test_clue.lua
@@ -2940,7 +2940,7 @@ T['Reproducing keys']['works for builtin keymaps in Terminal mode'] = function()
   child.cmd('wincmd v')
   child.cmd('terminal')
   -- Wait for terminal to load
-  vim.loop.sleep(6 * small_time)
+  vim.uv.sleep(6 * small_time)
   child.cmd('startinsert')
   eq(child.fn.mode(), 't')
 
@@ -2959,7 +2959,7 @@ T['Reproducing keys']['works for user keymaps in Terminal mode'] = function()
   child.cmd('wincmd v')
   child.cmd('terminal')
   -- Wait for terminal to load
-  vim.loop.sleep(6 * small_time)
+  vim.uv.sleep(6 * small_time)
   child.cmd('startinsert')
   eq(child.fn.mode(), 't')
 

--- a/tests/test_deps.lua
+++ b/tests/test_deps.lua
@@ -210,7 +210,7 @@ local T = new_set({
       -- Mock `vim.notify()`
       mock_notify()
 
-      -- Mock `vim.loop.spawn()`
+      -- Mock `vim.uv.spawn()`
       mock_spawn()
 
       -- Mock getting reproducible timestamp
@@ -1168,7 +1168,7 @@ T['add()']['Install']['works when no information about number of cores is availa
       {},                            -- Checkout changes
     }
   ]])
-  child.lua('vim.loop.cpu_info = function() return nil end')
+  child.lua('vim.uv.cpu_info = function() return nil end')
   expect.no_error(function() add('user/new_plugin') end)
 end
 
@@ -1936,7 +1936,7 @@ T['update()']['works when no information about number of cores is available'] = 
     }
   ]])
   add('user/plugin_1')
-  child.lua('vim.loop.cpu_info = function() return nil end')
+  child.lua('vim.uv.cpu_info = function() return nil end')
   expect.no_error(update)
 end
 

--- a/tests/test_diff.lua
+++ b/tests/test_diff.lua
@@ -1066,7 +1066,7 @@ T['gen_source']['git()']['attaches only in readable file buffers'] = function()
   set_buf(new_scratch_buf())
   eq(is_buf_enabled(0), false)
 
-  child.lua('vim.loop.fs_realpath = function() return nil end')
+  child.lua('vim.uv.fs_realpath = function() return nil end')
   edit(test_file_path)
   eq(is_buf_enabled(0), false)
 
@@ -1251,7 +1251,7 @@ T['gen_source']['save()']['works'] = function()
   -- - Wait for `:checktime` itself to process
   for _ = 1, 100 do
     if child.api.nvim_buf_get_changedtick(0) ~= cur_changedtick then break end
-    vim.loop.sleep(small_time)
+    vim.uv.sleep(small_time)
   end
   if child.api.nvim_buf_get_changedtick(0) == cur_changedtick then
     MiniTest.skip('Could not wait for `silent! checktime` to take effect')

--- a/tests/test_files.lua
+++ b/tests/test_files.lua
@@ -54,13 +54,13 @@ local validate_tree = function(dir, ref_tree)
     local read_dir
     read_dir = function(path, res)
       res = res or {}
-      local fs = vim.loop.fs_scandir(path)
-      local name, fs_type = vim.loop.fs_scandir_next(fs)
+      local fs = vim.uv.fs_scandir(path)
+      local name, fs_type = vim.uv.fs_scandir_next(fs)
       while name do
         local cur_path = path .. '/' .. name
         table.insert(res, cur_path .. (fs_type == 'directory' and '/' or ''))
         if fs_type == 'directory' then read_dir(cur_path, res) end
-        name, fs_type = vim.loop.fs_scandir_next(fs)
+        name, fs_type = vim.uv.fs_scandir_next(fs)
       end
       return res
     end
@@ -366,7 +366,7 @@ T['open()']['handles problematic entry names'] = function()
 end
 
 T['open()']['handles backslash on Unix'] = function()
-  if child.lua_get('vim.loop.os_uname().sysname') == 'Windows_NT' then MiniTest.skip('Test is not for Windows.') end
+  if child.lua_get('vim.uv.os_uname().sysname') == 'Windows_NT' then MiniTest.skip('Test is not for Windows.') end
 
   local temp_dir = make_temp_dir('temp', { '\\', 'hello\\', 'wo\\rld' })
   open(temp_dir)
@@ -739,8 +739,8 @@ T['open()']['`content.prefix` is called only on visible part of preview'] = func
     end
 
     _G.scandir_log = {}
-    fs_scandir_orig = vim.loop.fs_scandir
-    vim.loop.fs_scandir = function(path)
+    fs_scandir_orig = vim.uv.fs_scandir
+    vim.uv.fs_scandir = function(path)
       table.insert(_G.scandir_log, path)
       return fs_scandir_orig(path)
     end
@@ -2727,7 +2727,7 @@ T['Preview']['works for files'] = function()
 
   -- Should not error on files which failed to read (looks like on Windows it
   -- can be different from "non-readable" files)
-  child.lua('vim.loop.fs_open = function() return nil end')
+  child.lua('vim.uv.fs_open = function() return nil end')
   type_keys('j')
   expect_screenshot()
 end
@@ -3680,8 +3680,8 @@ T['File manipulation']['can move to trash across devices'] = function()
   local trash_dir = join_path(data_dir, 'mini.files', 'trash')
   child.lua('MiniFiles.config.options.permanent_delete = false')
 
-  -- Mock `vim.loop.fs_rename()` not working across devices/volumes/partitions
-  child.lua('vim.loop.fs_rename = function() return nil, "EXDEV: cross-device link not permitted:", "EXDEV" end')
+  -- Mock `vim.uv.fs_rename()` not working across devices/volumes/partitions
+  child.lua('vim.uv.fs_rename = function() return nil, "EXDEV: cross-device link not permitted:", "EXDEV" end')
 
   local temp_dir = make_temp_dir('temp', { 'file', 'dir/', 'dir/nested/', 'dir/nested/file' })
   open(temp_dir)
@@ -4006,8 +4006,8 @@ end
 T['File manipulation']['can move across devices'] = function()
   child.set_size(10, 60)
 
-  -- Mock `vim.loop.fs_rename()` not working across devices/volumes/partitions
-  child.lua('vim.loop.fs_rename = function() return nil, "EXDEV: cross-device link not permitted:", "EXDEV" end')
+  -- Mock `vim.uv.fs_rename()` not working across devices/volumes/partitions
+  child.lua('vim.uv.fs_rename = function() return nil, "EXDEV: cross-device link not permitted:", "EXDEV" end')
 
   local tmp_children = { 'dir/', 'dir/file', 'dir/nested/', 'dir/nested/sub/', 'dir/nested/sub/file' }
   local temp_dir = make_temp_dir('temp', tmp_children)
@@ -5676,7 +5676,7 @@ end
 T['Default explorer'] = new_set()
 
 T['Default explorer']['works on startup'] = function()
-  vim.loop.os_setenv('USE_AS_DEFAULT_EXPLORER', 'true')
+  vim.uv.os_setenv('USE_AS_DEFAULT_EXPLORER', 'true')
   child.restart({ '-u', make_test_path('init-default-explorer.lua'), '--', test_dir_path })
   child.expect_screenshot()
 
@@ -5688,7 +5688,7 @@ T['Default explorer']['works on startup'] = function()
 end
 
 T['Default explorer']['respects `options.use_as_default_explorer`'] = function()
-  vim.loop.os_setenv('USE_AS_DEFAULT_EXPLORER', 'false')
+  vim.uv.os_setenv('USE_AS_DEFAULT_EXPLORER', 'false')
   child.restart({ '-u', make_test_path('init-default-explorer.lua'), '--', test_dir_path })
   eq(child.bo.filetype, 'netrw')
 end

--- a/tests/test_git.lua
+++ b/tests/test_git.lua
@@ -500,7 +500,7 @@ T['show_at_cursor()']['works for range history in not tracked file'] = function(
 
   -- Mock real path presence
   child.lua([[
-    vim.loop.fs_realpath = function() return "/home/user/repo-root/source/of/symlink" end
+    vim.uv.fs_realpath = function() return "/home/user/repo-root/source/of/symlink" end
     vim.fn.isdirectory = function() return 1 end
   ]])
   child.lua([[_G.stdio_queue = { { { 'out', '/home/user/repo-root' } } }]])
@@ -1075,7 +1075,7 @@ T['show_range_history()'] = new_set({
       set_lines({ 'aaa', 'bbb', 'ccc' })
       child.fn.chdir(git_root_dir)
       child.api.nvim_buf_set_name(0, git_root_dir .. '/dir/tmp-file')
-      child.lua('vim.loop.fs_realpath = function(path) return path end')
+      child.lua('vim.uv.fs_realpath = function(path) return path end')
       child.lua([[_G.stdio_queue = {
         { { 'out', '' } },                           -- No uncommitted changes
         { { 'out', 'commit abc1234\nLog output' } }, -- Asked logs
@@ -1295,7 +1295,7 @@ T['show_range_history()']['uses correct working directory'] = function()
 end
 
 T['show_range_history()']['resolves symlinks'] = function()
-  child.lua('vim.loop.fs_realpath = function(path) return path .. "_symlink-source" end')
+  child.lua('vim.uv.fs_realpath = function(path) return path .. "_symlink-source" end')
   show_range_history()
 
   local ref_git_spawn_log = {
@@ -1457,7 +1457,7 @@ T['enable()']['does not work in non-file buffer'] = function()
 end
 
 T['enable()']['resolves symlinks'] = function()
-  child.lua('vim.loop.fs_realpath = function(path) return path .. "_symlink-source" end')
+  child.lua('vim.uv.fs_realpath = function(path) return path .. "_symlink-source" end')
 
   child.lua([[
     _G.stdio_queue = {
@@ -1796,7 +1796,7 @@ T['Tracking'] = new_set({
     pre_case = function()
       load_module()
       -- Ensure proper separators when dealing with paths
-      if helpers.is_windows() then child.lua('vim.loop.fs_realpath = function(path) return path end') end
+      if helpers.is_windows() then child.lua('vim.uv.fs_realpath = function(path) return path end') end
     end,
   },
 })
@@ -2398,9 +2398,9 @@ T[':Git']['works'] = function()
   ]])
 
   -- Should execute command synchronously
-  local start_time = vim.loop.hrtime()
+  local start_time = vim.uv.hrtime()
   child.cmd('Git log --oneline')
-  local duration = 0.000001 * (vim.loop.hrtime() - start_time)
+  local duration = 0.000001 * (vim.uv.hrtime() - start_time)
   eq(10 * small_time <= duration and duration <= 14 * small_time, true)
 
   -- Should properly gather subcommand data before executing command
@@ -2428,9 +2428,9 @@ T[':Git']['works asynchronously with bang modifier'] = function()
   ]])
 
   -- Should execute command asynchronously
-  local start_time = vim.loop.hrtime()
+  local start_time = vim.uv.hrtime()
   child.cmd('Git! log')
-  local duration = 0.000001 * (vim.loop.hrtime() - start_time)
+  local duration = 0.000001 * (vim.uv.hrtime() - start_time)
   eq(duration <= small_time, true)
 
   -- Should properly gather subcommand data before executing command
@@ -2813,9 +2813,9 @@ T[':Git']['respects `job.timeout`'] = function()
 
   child.lua('MiniGit.config.job.timeout = ' .. (2 * small_time))
 
-  local start_time = vim.loop.hrtime()
+  local start_time = vim.uv.hrtime()
   child.cmd('Git log')
-  local duration = 0.000001 * (vim.loop.hrtime() - start_time)
+  local duration = 0.000001 * (vim.uv.hrtime() - start_time)
   eq((1.5 * small_time) <= duration and duration <= (2.5 * small_time), true)
 
   local ref_notify_log = {

--- a/tests/test_icons.lua
+++ b/tests/test_icons.lua
@@ -376,9 +376,9 @@ T['get()']['caches output'] = function()
   local durations = child.lua([[
     local file = 'complex.file.name.which.should.fall.back.to.vim.filetype.match'
     local bench = function()
-      local start_time = vim.loop.hrtime()
+      local start_time = vim.uv.hrtime()
       MiniIcons.get('file', file)
-      return vim.loop.hrtime() - start_time
+      return vim.uv.hrtime() - start_time
     end
 
     local dur_no_cache = bench()
@@ -402,9 +402,9 @@ T['get()']['adds to cache resolved output in its original category'] = function(
   --   caching, the benchmarking is not stable.
   local durations = child.lua([[
     local bench = function(category, name)
-      local start_time = vim.loop.hrtime()
+      local start_time = vim.uv.hrtime()
       MiniIcons.get(category, name)
-      return vim.loop.hrtime() - start_time
+      return vim.uv.hrtime() - start_time
     end
 
     -- "file" category resolving to manually tracked "extension"
@@ -443,9 +443,9 @@ end
 T['get()']['uses cached extension during "file" resolution'] = function()
   local durations = child.lua([[
     local bench = function(category, name)
-      local start_time = vim.loop.hrtime()
+      local start_time = vim.uv.hrtime()
       MiniIcons.get(category, name)
-      return vim.loop.hrtime() - start_time
+      return vim.uv.hrtime() - start_time
     end
 
     -- Known extension (i.e. not falling back to default)
@@ -487,9 +487,9 @@ T['get()']['prefers user configured data over `vim.filetype.match()`'] = functio
 
   local durations = child.lua([[
     local bench = function(category, name)
-      local start_time = vim.loop.hrtime()
+      local start_time = vim.uv.hrtime()
       MiniIcons.get(category, name)
-      return vim.loop.hrtime() - start_time
+      return vim.uv.hrtime() - start_time
     end
 
     local ext_fallback = bench('extension', 'not-supported-extension')

--- a/tests/test_misc.lua
+++ b/tests/test_misc.lua
@@ -82,7 +82,7 @@ T['bench_time()'] = new_set({
   hooks = {
     pre_case = function()
       child.lua('_G.small_time = ' .. small_time)
-      child.lua('_G.f = function(ms) ms = ms or _G.small_time; vim.loop.sleep(ms); return ms end')
+      child.lua('_G.f = function(ms) ms = ms or _G.small_time; vim.uv.sleep(ms); return ms end')
     end,
   },
 })

--- a/tests/test_notify.lua
+++ b/tests/test_notify.lua
@@ -43,7 +43,7 @@ local mock_gettimeofday = function()
 
   local lua_cmd = string.format(
     [[local start, n = %d, -1
-      vim.loop.gettimeofday = function()
+      vim.uv.gettimeofday = function()
         n = n + 1
         return start + n, %d
       end]],
@@ -281,7 +281,7 @@ T['make_notify()']['has output working in fast event'] = function()
   child.lua('_G.dur = ' .. small_time)
   child.lua([[
     vim.notify = MiniNotify.make_notify()
-    local timer = vim.loop.new_timer()
+    local timer = vim.uv.new_timer()
     timer:start(_G.dur, 0, function() vim.notify('Hello', vim.log.levels.INFO) end)
   ]])
   sleep(small_time + small_time)
@@ -344,7 +344,7 @@ T['add()']['works'] = function()
   eq(notif.hl_group, 'MiniNotifyNormal')
   eq(notif.data, {})
 
-  -- Timestamp fields should use `vim.loop.gettimeofday()`
+  -- Timestamp fields should use `vim.uv.gettimeofday()`
   eq(notif.ts_add, ref_seconds + ref_microseconds)
   eq(notif.ts_update, notif.ts_add)
 end
@@ -569,7 +569,7 @@ T['refresh()']['can be used inside fast event'] = function()
   add('Hello')
   child.lua('_G.dur = ' .. small_time)
   child.lua([[
-    local timer = vim.loop.new_timer()
+    local timer = vim.uv.new_timer()
     timer:start(_G.dur, 0, function() MiniNotify.refresh() end)
   ]])
   sleep(small_time + small_time)

--- a/tests/test_pick.lua
+++ b/tests/test_pick.lua
@@ -753,7 +753,7 @@ T['start()']['respects `delay.async`'] = function()
   child.lua('_G.small_time = ' .. small_time)
   child.lua_notify([[
     _G.buf_id, _G.n = vim.api.nvim_get_current_buf(), 0
-    local timer = vim.loop.new_timer()
+    local timer = vim.uv.new_timer()
     local f = vim.schedule_wrap(function()
       _G.n = _G.n + 1
       vim.fn.appendbufline(_G.buf_id, '$', { 'Line ' .. _G.n })
@@ -1120,7 +1120,7 @@ T['default_match()']['does not block query update'] = function()
     -- Mock slow matching
     local find_orig = string.find
     string.find = function(...)
-      vim.loop.sleep(_G.small_time)
+      vim.uv.sleep(_G.small_time)
       return find_orig(...)
     end
 
@@ -1664,7 +1664,7 @@ T['default_preview()']['works for file path'] = function()
   stop()
 
   -- Should work for failed to read files
-  child.lua('vim.loop.fs_open = function() return nil end')
+  child.lua('vim.uv.fs_open = function() return nil end')
   local makefile_path = real_file('Makefile')
   validate_preview({ makefile_path })
   validate_helper_buf_name(0, 'preview')
@@ -4063,9 +4063,9 @@ T['set_picker_items()']['respects `opts.querytick`'] = function()
     -- Mock slow item preparation
     local tolower_orig = vim.fn.tolower
     vim.fn.tolower = function(...)
-      table.insert(_G.log, { time = vim.loop.hrtime(), args = {...} })
-      vim.loop.sleep(_G.small_time)
-      table.insert(_G.log, { time = vim.loop.hrtime() })
+      table.insert(_G.log, { time = vim.uv.hrtime(), args = {...} })
+      vim.uv.sleep(_G.small_time)
+      table.insert(_G.log, { time = vim.uv.hrtime() })
       return tolower_orig(...)
     end
 
@@ -4189,7 +4189,7 @@ T['set_picker_items_from_cli()']['stops process if picker is stopped'] = functio
   child.lua('_G.delay = ' .. delay)
   child.lua([[
     local is_active_indicator = true
-    vim.loop.spawn = function(path, options, on_exit)
+    vim.uv.spawn = function(path, options, on_exit)
       vim.defer_fn(on_exit, _G.delay)
 
       local process = {
@@ -4199,7 +4199,7 @@ T['set_picker_items_from_cli()']['stops process if picker is stopped'] = functio
       }
       return process, pid
     end
-    vim.loop.process_kill = function(process)
+    vim.uv.process_kill = function(process)
       -- Killing process also means it stops being active
       is_active_indicator = false
       table.insert(_G.process_log, 'Process Pid_1 was killed.')
@@ -6154,7 +6154,7 @@ T['Paste']['respects `delay.async` when waiting for register label'] = function(
   child.lua('_G.small_time = ' .. small_time)
   child.lua_notify([[
     _G.buf_id, _G.n = vim.api.nvim_get_current_buf(), 0
-    local timer = vim.loop.new_timer()
+    local timer = vim.uv.new_timer()
     local f = vim.schedule_wrap(function()
       _G.n = _G.n + 1
       vim.fn.appendbufline(_G.buf_id, '$', { 'Line ' .. _G.n })

--- a/tests/test_snippets.lua
+++ b/tests/test_snippets.lua
@@ -2989,8 +2989,8 @@ T['parse()']['respects `opts.normalize`'] = function()
   -- Evaluates variable only once
   child.lua([[
     _G.log = {}
-    local os_getenv_orig = vim.loop.os_getenv
-    vim.loop.os_getenv = function(...)
+    local os_getenv_orig = vim.uv.os_getenv
+    vim.uv.os_getenv = function(...)
       table.insert(_G.log, { ... })
       return os_getenv_orig(...)
     end
@@ -3153,7 +3153,7 @@ T['parse()']['can resolve special variables'] = function()
   validate('$CURRENT_SECONDS_UNIX', { { var = 'CURRENT_SECONDS_UNIX', text = '111' }, final_tabstop })
 
   -- Random values
-  child.lua('vim.loop.hrtime = function() return 101 end') -- mock reproducible `math.randomseed`
+  child.lua('vim.uv.hrtime = function() return 101 end') -- mock reproducible `math.randomseed`
   local ref_random = {
     { var = 'RANDOM', text = '491985' }, { var = 'RANDOM', text = '873024' },
     { var = 'RANDOM_HEX', text = '10347d' }, { var = 'RANDOM_HEX', text = 'df5ed0' },
@@ -4768,7 +4768,7 @@ T['Various snippets']['var'] = function()
   end
 
   -- Basic cases
-  child.lua('vim.loop.hrtime = function() return 101 end') -- mock reproducible `math.randomseed`
+  child.lua('vim.uv.hrtime = function() return 101 end') -- mock reproducible `math.randomseed`
   validate('$RANDOM ${RANDOM}', { '491985 873024' }, { 1, 13 })
 
   child.fn.setreg('"', 'abc\n')
@@ -5253,7 +5253,7 @@ end
 
 T['Examples']['customize variable evaluation'] = function()
   child.lua([[
-    vim.loop.os_setenv('USERNAME', 'user')
+    vim.uv.os_setenv('USERNAME', 'user')
     local insert_with_lookup = function(snippet)
       local lookup = {
         TM_SELECTED_TEXT = table.concat(vim.fn.getreg('a', true, true), '\n'),

--- a/tests/test_starter.lua
+++ b/tests/test_starter.lua
@@ -51,7 +51,7 @@ local get_active_items_names = function(buf_id)
 end
 
 local mock_user_and_time = function()
-  child.lua([[vim.loop.os_get_passwd = function() return { username = 'MINI' } end]])
+  child.lua([[vim.uv.os_get_passwd = function() return { username = 'MINI' } end]])
   child.lua([[vim.fn.strftime = function(x) return x == '%H' and '12' or '' end]])
 end
 

--- a/tests/test_statusline.lua
+++ b/tests/test_statusline.lua
@@ -181,12 +181,12 @@ T['setup()']['ensures content when working with built-in terminal'] = function()
 
   child.cmd('terminal! bash --noprofile --norc')
   -- Wait for terminal to get active
-  vim.loop.sleep(term_mode_wait)
+  vim.uv.sleep(term_mode_wait)
   validate_statusline(0, 'active')
   eq(child.api.nvim_get_current_buf() == init_buf_id, false)
 
   type_keys('i', 'exit', '<CR>')
-  vim.loop.sleep(term_mode_wait)
+  vim.uv.sleep(term_mode_wait)
   type_keys('<CR>')
   validate_statusline(0, 'active')
   eq(child.api.nvim_get_current_buf() == init_buf_id, true)

--- a/tests/test_test.lua
+++ b/tests/test_test.lua
@@ -1274,9 +1274,9 @@ end
 
 T['child']['type_keys()']['respects `wait` argument'] = function()
   local delay = helpers.get_time_const(100)
-  local start_time = vim.loop.hrtime()
+  local start_time = vim.uv.hrtime()
   child.type_keys(delay, 'i', 'Hello', { 'w', 'o' }, 'rld')
-  local end_time = vim.loop.hrtime()
+  local end_time = vim.uv.hrtime()
   local duration = (end_time - start_time) * 0.000001
   eq(0.9 * 5 * delay <= duration and duration <= 1.1 * 5 * delay, true)
 end
@@ -1581,7 +1581,7 @@ T['gen_reporter']['stdout'] = new_set({
     local command = string.format([[%s %s --headless --clean -n -u %s]], env_var, vim.v.progpath, vim.inspect(path))
     child.fn.termopen(command)
     -- Wait until check is done and possible process is ended
-    vim.loop.sleep(terminal_wait)
+    vim.uv.sleep(terminal_wait)
     local ignore_attr = child.fn.has('nvim-0.11') == 1 and {} or { 31, 32, 34, 35 }
     child.expect_screenshot({ ignore_attr = ignore_attr })
   end,

--- a/tests/test_visits.lua
+++ b/tests/test_visits.lua
@@ -122,7 +122,7 @@ local T = new_set({
       cleanup_index_file()
 
       -- Make `stdpath('data')` point to test directory
-      local lua_cmd = string.format([[vim.loop.os_setenv('XDG_DATA_HOME', %s)]], vim.inspect(xdg_data_home))
+      local lua_cmd = string.format([[vim.uv.os_setenv('XDG_DATA_HOME', %s)]], vim.inspect(xdg_data_home))
       child.lua(lua_cmd)
 
       -- Load module


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [X] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

## Description

All instances of `vim.loop` have been replaced with `vim.uv`.

- [X] Tests successful
- [X] Documentation has been updated accordingly

For more details, see #2085.