### PR TITLE
feat(pick): add functionality to remove and modify glob patterns during grep_live

### DIFF
--- a/doc/mini-pick.txt
+++ b/doc/mini-pick.txt
@@ -1138,7 +1138,8 @@ Pick from pattern matches with live feedback
 
 Perform pattern matching treating prompt as pattern. Gives live feedback on
 which matches are found. Use |MiniPick-actions-refine| to revert to regular
-matching. Use `<C-o>` to restrict search to files matching glob patterns.
+matching. Use `<C-o>` to restrict search to files matching glob patterns,
+`<C-S-O>` to remove glob patterns, `<C-m>` to modify glob patterns.
 Tries to use one of the CLI tools to create items (see |MiniPick-cli-tools|):
 `rg`, `git`. If none is present, error is thrown (for performance reasons).
 
@@ -1154,6 +1155,8 @@ Parameters ~
     specific glob syntax and effects. Default: `{}` (no restriction).
     Example: `{ '*.lua', 'lua/**' }` for Lua files and files in "lua" directory.
     Use `<C-o>` custom mapping to add glob to the array.
+    Use `<C-S-O>` custom mapping to remove glob from the array.
+    Use `<C-m>` custom mapping to modify glob inside the array.
 {opts} `(table|nil)` Options forwarded to |MiniPick.start()|.
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

grep_live picker has `<C-o>` custom mapping to add glob to the array. Propose to expand this type of functionality with `<C-S-O>` custom mapping to remove glob from the array and `<C-m>` custom mapping to modify glob inside the array.

Looks like this when press `<C-S-O>`. Modifying with `<C-m>` looks similar but after hit a number, it prompts current glob and allows to change and confirm like `<C-o>`. Uses common for `mini.nvim` functions `H.user_input` and `H.echo` for input and output.
<img width="901" height="567" alt="image" src="https://github.com/user-attachments/assets/874cff0e-5321-4070-bb04-5b778b04b2df" />
