### PR TITLE
feat(files): allow dynamic `width_preview`

### DIFF
--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -611,8 +611,12 @@ Defaults ~
       width_focus = 50,
       -- Width of non-focused window
       width_nofocus = 15,
-      -- Width of preview window
+      -- Width of preview window (0 to fit preview buffer content)
       width_preview = 25,
+      -- Maximum width of preview window (used when width_preview is 0)
+      width_preview_max = 80,
+      -- Minimum width of preview window (used when width_preview is 0)
+      width_preview_min = 15,
     },
   }
 <


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

## Problem

Using a fixed `width_preview` is a bit limiting: depending on the previewed buffer content, it can feel either too small (_ie. hiding too much of the content_) or too big (_ie. showing many blank spaces_).

## Proposal

Allow dynamic preview width by setting `width_preview` configuration field to `0`.  
In such case, the width is computed from the buffer content, bounded in an interval defined by new `width_preview_min` and `width_preview_max` new configuration fields.

In more details:
- `width_preview_min` and `width_preview_max` are added to the config
- `H.set_buflines` records (in `H.opened_buffers`) the value of the longest line
- all direct uses of `width_preview` are replaced by a call to a `H.window_compute_preview_width`function which:
    - directly returns `width_preview` if its value is positive
    - otherwise, returns the buffer number of columns from `H.opened_buffers` (clipped in the minimum/maximum interval)

## Example

```vim
:!mkdir foo
:!echo "small" > foo/small
:!echo "a pretty big sentence that should be displayed entirely in the preview" > foo/big
:!echo "this is way toooooooooooooooooooooooooooooooooooooooooooooooooooooo long and wont completely show" > foo/too_big

:lua _G.windows =  { preview = true, width_preview = 0, width_preview_min = 10, width_preview_max = 80 }
:lua MiniFiles.open('foo', false, { windows = _G.windows })
```
 - the preview of `foo/small` uses the minimal width of `10`
 - the preview of `foo/big` fits the file content (ie. width of `70`)
 - the preview of `foo/too_big` uses the maximal width of `80`, as file content is too large 
