### PR TITLE
feat(icons): add glyph for unlicense icon

### DIFF
--- a/lua/mini/icons.lua
+++ b/lua/mini/icons.lua
@@ -881,6 +881,7 @@ H.file_icons = {
   LICENSE                = { glyph = '', hl = 'MiniIconsCyan'   },
   ['LICENSE.md']         = { glyph = '', hl = 'MiniIconsCyan'   },
   ['LICENSE.txt']        = { glyph = '', hl = 'MiniIconsCyan'   },
+  UNLICENSE              = { glyph = '', hl = 'MiniIconsCyan'   },
   NEWS                   = { glyph = '󰎕', hl = 'MiniIconsBlue'   },
   ['NEWS.md']            = { glyph = '󰎕', hl = 'MiniIconsBlue'   },
   PKGBUILD               = { glyph = '󱁤', hl = 'MiniIconsPurple' },


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Adds a `UNLICENSE` glyph to `mini.icons`:

No behavior changes; just extends the icon set.

Note: The repo has unrelated failing tests, but this change only touches mini.icons and does not break its functionality.
