### PR TITLE
fix(pick/error): `set_picker_items ` don't throw an `error` if `picker is inactive`

### DIFF
--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -1698,8 +1698,8 @@ MiniPick.get_picker_query = function() return vim.deepcopy((H.pickers.active or 
 ---
 ---@seealso |MiniPick.get_picker_items()| and |MiniPick.get_picker_stritems()|
 MiniPick.set_picker_items = function(items, opts)
-  if not H.islist(items) then H.error('`items` should be an array.') end
   if not MiniPick.is_picker_active() then return end
+  if not H.islist(items) then H.error('`items` should be an array.') end
   opts = vim.tbl_deep_extend('force', { do_match = true, querytick = nil }, opts or {})
 
   -- Set items in async because computing lower `stritems` can block much time


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

## Why
Everywhere else in the entire module, `MiniPick.is_picker_active` is checked before the assertion section. For example:
```lua
MiniPick.set_picker_items_from_cli = function(command, opts)
  if not MiniPick.is_picker_active() then return end
  local is_valid_command = H.is_array_of(command, 'string') and #command >= 1
  if not is_valid_command then H.error('`command` should be an array of strings.') end
```

The alternative behavior is not described in the documentation for the method.