### PR TITLE
Fix: interaction with ghost text (#2166)

### DIFF
--- a/lua/mini/pairs.lua
+++ b/lua/mini/pairs.lua
@@ -311,7 +311,7 @@ end
 MiniPairs.close = function(pair, neigh_pattern)
   local close = H.get_close_char(pair)
   local move_right = not H.is_disabled() and H.neigh_match(neigh_pattern) and H.get_neigh('right') == close
-  return move_right and H.get_arrow_key('right', true) or close
+  return move_right and (H.keys.del .. close) or close
 end
 
 --- Process "closeopen" symbols
@@ -329,7 +329,7 @@ end
 ---@return string Keys performing "closeopen" action.
 MiniPairs.closeopen = function(pair, neigh_pattern)
   local move_right = not H.is_disabled() and H.get_neigh('right') == H.get_close_char(pair)
-  return move_right and H.get_arrow_key('right', true) or MiniPairs.open(pair, neigh_pattern)
+  return move_right and (H.keys.del .. H.get_close_char(pair)) or MiniPairs.open(pair, neigh_pattern)
 end
 
 --- Process |<BS>|


### PR DESCRIPTION
Ref: nvim-mini/mini.nvim#2166

This is my attempt at fixing  a specific problem. It did fix it, but I'm not an expert on mini.pairs, so hope it didn't break something else ;)

The problem:

When a ghost text (e.g. from copilot) appears between the cursor and the closing pair:

`"some string content <cursor>some ghost text from copilot"`

The current behaviour of just moving forward, instead of typing the closing quote character doesn't work. It just moves the cursor forward inside the ghost text:

`"some string content s<cursor>ome ghost text from copilot"`

The solution is to actually type the end quote, and delete the character ahead.

- [ ] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [ ] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
