### PR TITLE
feat(clue): implementation of arratys as keys or modes in clue triggers

### DIFF
--- a/lua/mini/clue.lua
+++ b/lua/mini/clue.lua
@@ -1964,19 +1964,14 @@ end
 -- Predicates -----------------------------------------------------------------
 H.is_trigger = function(x)
   if type(x) ~= table then return false end;
-  if type(x.mode) == "string" and type(x.keys) == "string" then
-    return true
-  else
-    if type(x.mode) == "table" then
-      for _, v in ipairs(x.mode) do
-        if type(v) ~= "string" then return false end
-      end
-    end
-    if type(x.keys) == "table" then
-      for _, v in ipairs(x.keys) do
-        if type(v) ~= "string" then return false end
-      end
-    end
+  local modes = type(x.mode) == "string" and {x.mode} or x.mode
+  local keys  = type(x.keys) == "string" and {x.keys} or x.keys
+  if type(modes) ~= "table" or type(keys) ~= "table" then return false end
+  for _, v in ipairs(modes) do
+    if type(v) ~= "string" then return false end
+  end
+  for _, v in ipairs(modes) do
+    if type(v) ~= "string" then return false end
   end
   return true
 end


### PR DESCRIPTION
implementation of feature i requested in
- #2192

example of mini.clue's triggers with my changes
``` lua
triggers = {
  {
    mode = { 'n', 'x' },
    keys = {
      '<Leader>', 'g', "'", '`', '"', 'z'
    }
  },

  { mode = 'i',          keys = '<C-x>' },

  { mode = { 'i', 'c' }, keys = '<C-r>' },

  { mode = 'n',          keys = '<C-w>' },
},


```

- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)