### PR TITLE
fix(starter): close buffer before eval to prevent mapping interferences

### DIFF
--- a/lua/mini/starter.lua
+++ b/lua/mini/starter.lua
@@ -894,9 +894,10 @@ MiniStarter.eval_current_item = function(buf_id)
   if not H.validate_starter_buf_id(buf_id, 'eval_current_item()') then return end
 
   -- Reset query before evaluation without query echo (avoids hit-enter-prompt)
-  H.make_query(vim.api.nvim_get_current_buf(), '', false)
+  H.make_query(buf_id, '', false)
 
   local data = H.buffer_data[buf_id]
+  MiniStarter.close(buf_id)
   H.eval_fun_or_string(data.items[data.current_item_id].action, true)
 end
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

**Problem:** 
mini.starter buffer mappings interfere with opened files when using `evaluate_single = true` with query based selection.

**Solution:** 
Close starter buffer before executing action in `eval_current_item`.

**Changes:**
- Use `close()` before action execution
- Fix `H.make_query()` buffer ID and use it in the closing

**Testing:** 
With `evaluate_single = true`, press 0 really fast to select item and navigation now works correctly.
