### PR TITLE
feat(pick): add _with_focus_lock function to support text jump

### DIFF
--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -2199,6 +2199,16 @@ H.picker_new = function(opts)
   return picker
 end
 
+MiniPick._with_focus_lock = function(fn)
+  if type(H.cache) ~= 'table' then return fn() end
+  local prev = H.cache.is_in_getcharstr
+  H.cache.is_in_getcharstr = true
+  local ok, result = pcall(fn)
+  H.cache.is_in_getcharstr = prev
+  if not ok then error(result) end
+  return result
+end
+
 H.picker_advance = function(picker)
   vim.schedule(function() vim.api.nvim_exec_autocmds('User', { pattern = 'MiniPickStart' }) end)
 


### PR DESCRIPTION
Title: Add _with_focus_lock function to support text jump

Description:
This enables usage of leap, and probably flash too, to jump to results, making the picker more on par with snacks.picker/fzf-lua. This was a missing feature I had to patch in to make leaping work.

Here is an example action for mini.pick:
```lua
MiniPick.setup({
  mappings = {
    move_down = '<C-n>',
    move_start = '<C-g>',
    leap = {
      char = '<M-s>',
      func = function()
        local state = MiniPick.get_picker_state()
        if not state or not state.windows or not state.windows.main then return end
        local win_id = state.windows.main
        local run = function()
          require('leap').leap({
            target_windows = { win_id },
            action = function(target)
              local current_line = vim.api.nvim_win_get_cursor(win_id)[1]
              local delta = target.pos[1] - current_line
              if delta == 0 then return end
              local key = delta >= 0 and '<C-n>' or '<C-p>'
              for _ = 1, math.abs(delta) do
                vim.api.nvim_input(key)
              end
            end,
          })
        end
        MiniPick._with_focus_lock(run)
      end,
    },
  },
})

```

https://github.com/user-attachments/assets/0268a5c4-369b-49bf-bba1-323e2d12992b


- [ ] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [ ] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
