### PR TITLE
fix(pick): don't cancel setting file picker items on user input

### DIFF
--- a/lua/mini/pick.lua
+++ b/lua/mini/pick.lua
@@ -3406,7 +3406,7 @@ H.set_picker_items_from_feed = function(feed, pattern, opts)
   if not MiniPick.is_picker_active() then return end
 
   -- NOTE: For intended effect, relies on presence of the active coroutine
-  local poke_picker = H.poke_picker_throttle(H.querytick)
+  local poke_picker = H.poke_picker_throttle()
 
   -- Realign feed so that each one ends in a pattern
   for i = 2, #feed do


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Typing matching input in the file picker before file list is loaded results in an empty picker. This can happen in folders with many files e.g. $HOME dir.

Fix: the CLI feed shouldn't abort because the user typed. Change the throttle call in `H.set_picker_items_from_feed` to not pass `H.querytick`.