### PR TITLE
fix(files): properly normalize root directory on Windows

### DIFF
--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -2632,7 +2632,11 @@ end
 
 H.fs_normalize_path = function(path) return (path:gsub('/+', '/'):gsub('(.)/$', '%1')) end
 if H.is_windows then
-  H.fs_normalize_path = function(path) return (path:gsub('\\', '/'):gsub('([^/])/+', '%1/'):gsub('(.)[\\/]$', '%1')) end
+  H.fs_normalize_path = function(path)
+    path = path:gsub('\\', '/'):gsub('([^/])/+', '%1/')
+    if path:find('^%w:[\\/].') then path = path:gsub('(.)[\\/]$', '%1') end
+    return path
+  end
 end
 
 H.fs_is_imaginary_path = function(path) return path:sub(-1) == '\000' end

--- a/tests/test_files.lua
+++ b/tests/test_files.lua
@@ -1021,6 +1021,12 @@ T['open()']['respects `vim.b.minifiles_config`'] = function()
   child.expect_screenshot()
 end
 
+T['open()']['properly normalizes root directory on Windows'] = function()
+  if child.loop.os_uname().sysname ~= 'Windows_NT' then MiniTest.skip('Test is only for Windows.') end
+  open('C:/')
+  eq(get_explorer_state().branch, { 'C:/' })
+end
+
 T['refresh()'] = new_set()
 
 local refresh = forward_lua('MiniFiles.refresh')


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Fixes the issue described in #2272 based on the findings of https://github.com/nvim-mini/mini.nvim/pull/2272#issuecomment-3930187872