### PR TITLE
docs(git): fixed left/right quotation marks instead of apostrophes

### DIFF
--- a/readmes/mini-ai.md
+++ b/readmes/mini-ai.md
@@ -76,8 +76,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                 |
     |--------|--------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.ai’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.ai’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.ai')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.ai', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-align.md
+++ b/readmes/mini-align.md
@@ -73,8 +73,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                    |
     |--------|-----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.align’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.align’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.align')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.align', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-animate.md
+++ b/readmes/mini-animate.md
@@ -69,8 +69,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                      |
     |--------|-------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.animate’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.animate’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.animate')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.animate', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-base16.md
+++ b/readmes/mini-base16.md
@@ -108,8 +108,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                     |
     |--------|------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.base16’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.base16’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.base16')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.base16', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-basics.md
+++ b/readmes/mini-basics.md
@@ -66,8 +66,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                     |
     |--------|------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.basics’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.basics’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.basics')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.basics', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-bracketed.md
+++ b/readmes/mini-bracketed.md
@@ -92,8 +92,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                        |
     |--------|---------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.bracketed’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.bracketed’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.bracketed')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.bracketed', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-bufremove.md
+++ b/readmes/mini-bufremove.md
@@ -59,8 +59,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                        |
     |--------|---------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.bufremove’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.bufremove’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.bufremove')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.bufremove', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-clue.md
+++ b/readmes/mini-clue.md
@@ -163,8 +163,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                   |
     |--------|----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.clue’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.clue’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.clue')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.clue', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-cmdline.md
+++ b/readmes/mini-cmdline.md
@@ -62,8 +62,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                      |
     |--------|-------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.cmdline’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.cmdline’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.cmdline')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.cmdline', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-colors.md
+++ b/readmes/mini-colors.md
@@ -91,8 +91,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                     |
     |--------|------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.colors’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.colors’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.colors')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.colors', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-comment.md
+++ b/readmes/mini-comment.md
@@ -63,8 +63,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                      |
     |--------|-------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.comment’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.comment’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.comment')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.comment', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-completion.md
+++ b/readmes/mini-completion.md
@@ -87,8 +87,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                         |
     |--------|----------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.completion’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.completion’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.completion')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.completion', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-cursorword.md
+++ b/readmes/mini-cursorword.md
@@ -57,8 +57,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                         |
     |--------|----------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.cursorword’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.cursorword’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.cursorword')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.cursorword', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-diff.md
+++ b/readmes/mini-diff.md
@@ -156,8 +156,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                   |
     |--------|----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.diff’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.diff’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.diff')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.diff', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-doc.md
+++ b/readmes/mini-doc.md
@@ -57,8 +57,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                  |
     |--------|---------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.doc’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.doc’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.doc')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.doc', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-extra.md
+++ b/readmes/mini-extra.md
@@ -81,8 +81,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                    |
     |--------|-----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.extra’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.extra’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.extra')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.extra', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-files.md
+++ b/readmes/mini-files.md
@@ -115,8 +115,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                    |
     |--------|-----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.files’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.files’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.files')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.files', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-fuzzy.md
+++ b/readmes/mini-fuzzy.md
@@ -54,8 +54,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                    |
     |--------|-----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.fuzzy’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.fuzzy’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.fuzzy')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.fuzzy', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-git.md
+++ b/readmes/mini-git.md
@@ -75,8 +75,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                  |
     |--------|---------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini-git’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini-git’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini-git')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini-git', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-hipatterns.md
+++ b/readmes/mini-hipatterns.md
@@ -83,8 +83,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                         |
     |--------|----------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.hipatterns’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.hipatterns’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.hipatterns')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.hipatterns', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-hues.md
+++ b/readmes/mini-hues.md
@@ -187,8 +187,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                   |
     |--------|----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.hues’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.hues’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.hues')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.hues', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-icons.md
+++ b/readmes/mini-icons.md
@@ -95,8 +95,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                    |
     |--------|-----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.icons’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.icons’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.icons')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.icons', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-indentscope.md
+++ b/readmes/mini-indentscope.md
@@ -62,8 +62,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                          |
     |--------|-----------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.indentscope’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.indentscope’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.indentscope')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.indentscope', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-jump.md
+++ b/readmes/mini-jump.md
@@ -60,8 +60,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                   |
     |--------|----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.jump’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.jump’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.jump')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.jump', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-jump2d.md
+++ b/readmes/mini-jump2d.md
@@ -70,8 +70,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                     |
     |--------|------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.jump2d’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.jump2d’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.jump2d')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.jump2d', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-keymap.md
+++ b/readmes/mini-keymap.md
@@ -128,8 +128,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                     |
     |--------|------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.keymap’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.keymap’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.keymap')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.keymap', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-map.md
+++ b/readmes/mini-map.md
@@ -76,8 +76,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                  |
     |--------|---------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.map’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.map’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.map')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.map', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-misc.md
+++ b/readmes/mini-misc.md
@@ -66,8 +66,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                   |
     |--------|----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.misc’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.misc’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.misc')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.misc', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-move.md
+++ b/readmes/mini-move.md
@@ -65,8 +65,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                   |
     |--------|----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.move’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.move’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.move')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.move', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-notify.md
+++ b/readmes/mini-notify.md
@@ -63,8 +63,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                     |
     |--------|------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.notify’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.notify’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.notify')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.notify', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-operators.md
+++ b/readmes/mini-operators.md
@@ -68,8 +68,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                        |
     |--------|---------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.operators’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.operators’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.operators')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.operators', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-pairs.md
+++ b/readmes/mini-pairs.md
@@ -57,8 +57,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                    |
     |--------|-----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.pairs’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.pairs’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.pairs')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.pairs', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-pick.md
+++ b/readmes/mini-pick.md
@@ -179,8 +179,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                   |
     |--------|----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.pick’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.pick’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.pick')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.pick', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-sessions.md
+++ b/readmes/mini-sessions.md
@@ -60,8 +60,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                       |
     |--------|--------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.sessions’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.sessions’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.sessions')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.sessions', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-snippets.md
+++ b/readmes/mini-snippets.md
@@ -265,8 +265,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                       |
     |--------|--------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.snippets’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.snippets’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.snippets')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.snippets', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-splitjoin.md
+++ b/readmes/mini-splitjoin.md
@@ -81,8 +81,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                        |
     |--------|---------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.splitjoin’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.splitjoin’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.splitjoin')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.splitjoin', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-starter.md
+++ b/readmes/mini-starter.md
@@ -61,8 +61,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                      |
     |--------|-------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.starter’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.starter’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.starter')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.starter', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-statusline.md
+++ b/readmes/mini-statusline.md
@@ -67,8 +67,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                         |
     |--------|----------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.statusline’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.statusline’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.statusline')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.statusline', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-surround.md
+++ b/readmes/mini-surround.md
@@ -73,8 +73,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                       |
     |--------|--------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.surround’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.surround’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.surround')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.surround', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-tabline.md
+++ b/readmes/mini-tabline.md
@@ -67,8 +67,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                      |
     |--------|-------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.tabline’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.tabline’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.tabline')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.tabline', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-test.md
+++ b/readmes/mini-test.md
@@ -67,8 +67,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                   |
     |--------|----------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.test’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.test’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.test')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.test', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-trailspace.md
+++ b/readmes/mini-trailspace.md
@@ -57,8 +57,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                         |
     |--------|----------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.trailspace’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.trailspace’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.trailspace')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.trailspace', checkout = 'stable' })` |
 
 </details>
 

--- a/readmes/mini-visits.md
+++ b/readmes/mini-visits.md
@@ -132,8 +132,8 @@ Here are code snippets for some common installation methods (use only one):
 
     | Branch | Code snippet                                                     |
     |--------|------------------------------------------------------------------|
-    | Main   | `add(‘nvim-mini/mini.visits’)`                                   |
-    | Stable | `add({ source = ‘nvim-mini/mini.visits’, checkout = ‘stable’ })` |
+    | Main   | `add('nvim-mini/mini.visits')`                                   |
+    | Stable | `add({ source = 'nvim-mini/mini.visits', checkout = 'stable' })` |
 
 </details>
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

In all of READMEs in the copy-and-paste snippet code blocks sections instead of normal apostrophes `'` there were left and right quotes surrounding the code, which caused the copy-and-paste to not work:

`‘` U+2018 : LEFT SINGLE QUOTATION MARK {single turned comma quotation mark}
`’` U+2019 : RIGHT SINGLE QUOTATION MARK {single comma quotation mark}

Now they're all replaced with normal apostrophes.

I've used regex to replace them, but I've checked them all manually before submitting a pr.

The only places where those quotes are left in the project are in the `*Follow recommended ‘mini.deps’ installation*` sections and one right quote `’` in `tests/dir-git/help-output:31`: `Remove remote branches that don’t have a local counterpart.` somehow (lol).