### PR TITLE
test(surround): fix problematic query after treesitter bump on Nightly

### DIFF
--- a/tests/mock-treesitter/queries/lua/textobjects.scm
+++ b/tests/mock-treesitter/queries/lua/textobjects.scm
@@ -26,4 +26,4 @@
 
 ((string) @string_offset (#offset! @string_offset 0 1 0 -2))
 
-(chunk [(function_declaration) (assignment_statement)]* @chunk.inner) @chunk.outer
+((chunk) @chunk.inner @chunk.outer (#offset! @chunk.inner 1 0 -1 0))

--- a/tests/test_surround.lua
+++ b/tests/test_surround.lua
@@ -477,7 +477,7 @@ T['gen_spec']['input']['treesitter()']['works with row-exclusive, col-0 end rang
   }]])
 
   local lines = get_lines()
-  validate_find(lines, { 4, 0 }, { { 11, 2 }, { 13, 7 }, { 1, 0 }, { 2, 0 } }, type_keys, 'sf', 'c')
+  validate_find(lines, { 4, 0 }, { { 13, 0 }, { 13, 7 }, { 1, 0 }, { 1, 11 } }, type_keys, 'sf', 'c')
 end
 
 T['gen_spec']['input']['treesitter()']['respects plugin options'] = function()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Should fix the failling test seen on https://github.com/nvim-mini/mini.nvim/actions/runs/22435966865/job/64965761703?pr=2284

The change in treesitter behavior seems to have been introduced by https://github.com/tree-sitter/tree-sitter/pull/5317 . I'm still waiting for more information before opening an issue in https://github.com/tree-sitter/tree-sitter , but Clason's opinion is that this may have been an unintentional behavior previously and the current behavior is more in line with how alternations work