### PR TITLE
test(ALL): on Nightly `nvim_win_get_config ()` always returns "style"

### DIFF
--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -367,7 +367,6 @@ Callback for each file action event will receive `data` field
 - <to> - full path of entry after action (`nil` for permanent "delete" action).
 
 ------------------------------------------------------------------------------
-                                                            *MiniFiles-examples*
 # Toggle explorer ~
 
 Use a combination of |MiniFiles.open()| and |MiniFiles.close()|: >lua
@@ -404,6 +403,11 @@ updated internally. Use `MiniFilesWindowUpdate` event for them: >lua
 
       -- Ensure fixed height
       config.height = 10
+
+------------------------------------------------------------------------------
+                                                            *MiniFiles-examples*
+      -- Ensure style
+      config.style = nil
 
       -- Ensure no title padding
       local n = #config.title

--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -398,6 +398,9 @@
 ---
 ---       -- Ensure fixed height
 ---       config.height = 10
+
+---       -- Ensure style
+---       config.style = nil
 ---
 ---       -- Ensure no title padding
 ---       local n = #config.title

--- a/tests/test_files.lua
+++ b/tests/test_files.lua
@@ -5523,6 +5523,8 @@ T['Events']['`MiniFilesWindowUpdate` can customize internally set window config 
         local config = vim.api.nvim_win_get_config(args.data.win_id)
         -- Ensure fixed height
         config.height = 5
+        -- Ensure style
+        config.style = nil
         -- Ensure title padding
         local n = #config.title
         config.title[1][1] = config.title[1][1]:gsub('^ ', '')

--- a/tests/test_map.lua
+++ b/tests/test_map.lua
@@ -385,10 +385,13 @@ T['open()']['correctly computes window config'] = function()
   map_open()
   local win_id = get_map_win_id()
 
-  local hide, mouse, border
+  local hide, mouse, border, style
   if child.fn.has('nvim-0.10') == 1 then hide = false end
   if child.fn.has('nvim-0.11') == 1 then mouse = false end
-  if child.fn.has('nvim-0.12') == 1 then border = 'none' end
+  if child.fn.has('nvim-0.12') == 1 then
+    border = 'none'
+    style = 'minimal'
+  end
   eq(child.api.nvim_win_get_config(win_id), {
     anchor = 'NE',
     border = border,
@@ -400,6 +403,7 @@ T['open()']['correctly computes window config'] = function()
     mouse = mouse,
     relative = 'editor',
     row = 0,
+    style = style,
     width = 10,
     zindex = 10,
   })


### PR DESCRIPTION
See PR 38122 in neovim/neovim

- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
