### PR TITLE
test(files): on nightly nvim_win_get_config now always returns "style"

### DIFF
--- a/doc/mini-files.txt
+++ b/doc/mini-files.txt
@@ -405,6 +405,9 @@ updated internally. Use `MiniFilesWindowUpdate` event for them: >lua
       -- Ensure fixed height
       config.height = 10
 
+      -- Ensure style
+      config.style = nil
+
       -- Ensure no title padding
       local n = #config.title
       config.title[1][1] = config.title[1][1]:gsub('^ ', '')

--- a/lua/mini/files.lua
+++ b/lua/mini/files.lua
@@ -399,6 +399,9 @@
 ---       -- Ensure fixed height
 ---       config.height = 10
 ---
+---       -- Ensure style
+---       config.style = nil
+---
 ---       -- Ensure no title padding
 ---       local n = #config.title
 ---       config.title[1][1] = config.title[1][1]:gsub('^ ', '')

--- a/tests/test_files.lua
+++ b/tests/test_files.lua
@@ -5523,6 +5523,8 @@ T['Events']['`MiniFilesWindowUpdate` can customize internally set window config 
         local config = vim.api.nvim_win_get_config(args.data.win_id)
         -- Ensure fixed height
         config.height = 5
+        -- Ensure style
+        config.style = nil
         -- Ensure title padding
         local n = #config.title
         config.title[1][1] = config.title[1][1]:gsub('^ ', '')


### PR DESCRIPTION
See PR 38122 in neovim/neovim

Details:
- This also affects the documentation as the test is about the officially documented example in MiniFiles-examples

- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
