### PR TITLE
test(ALL): fix tests that fail when using git worktree

### DIFF
--- a/tests/screenshots/tests-test_snippets.lua---Session---persists-after-`-edit`
+++ b/tests/screenshots/tests-test_snippets.lua---Session---persists-after-`-edit`
@@ -5,7 +5,7 @@
 4|~                                       
 5|~                                       
 6|~                                       
-7|</mini.nvim/tests/dir-snippets/tmp 1,4-5
+7|Dummy statusline                        
 8|-- INSERT --                            
 
 -|---------|---------|---------|---------|

--- a/tests/test_snippets.lua
+++ b/tests/test_snippets.lua
@@ -3550,6 +3550,9 @@ T['Session']['persists after `:edit`'] = function()
   child.cmd('edit')
   sleep(small_time)
 
+  -- Ensure expect_screenshot succeeds regardless of actual path
+  child.o.statusline = 'Dummy statusline'
+
   -- Should preserve both highlighting and data
   validate_active_session()
   child.expect_screenshot()

--- a/tests/test_tabline.lua
+++ b/tests/test_tabline.lua
@@ -356,20 +356,20 @@ T['make_tabline_string()']['deduplicates named labels'] = function()
   eq(eval_tabline(), ' dir1/aaa  dir2/aaa  dir1/dir_nested/aaa  dir2/dir_nested/aaa ')
 
   -- Should work for buffers without initial path
+  local expected = ' dir1/aaa  dir2/aaa  dir1/dir_nested/aaa  dir2/dir_nested/aaa '
   local buf_id = child.api.nvim_create_buf(true, false)
   child.api.nvim_buf_set_name(buf_id, 'aaa')
-  local cur_dir_basename = child.fn.fnamemodify(child.fn.getcwd(), ':t')
-  eq(
-    eval_tabline(),
-    (' dir1/aaa  dir2/aaa  dir1/dir_nested/aaa  dir2/dir_nested/aaa  %s/aaa '):format(cur_dir_basename)
-  )
+  -- Avoid truncation by ensuring that width is large enough to also hold part of cwd
+  expected = expected .. (' %s/aaa '):format(child.fn.fnamemodify(child.fn.getcwd(), ':t'))
+  child.o.columns = #expected
+  eq(eval_tabline(), expected)
 end
 
 T['make_tabline_string()']['deduplicates independent of current working directory'] = function()
   edit_path('dir1/aaa')
   edit_path('dir1/dir_nested/aaa')
 
-  child.cmd('cd tests/dir-tabline/dir1')
+  child.fn.chdir('tests/dir-tabline/dir1')
   eq(eval_tabline(), ' dir1/aaa  dir_nested/aaa ')
 end
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details(editted):
- When using git worktree, the mini.nvim repository is also checked-out under a different name. That causes some tests to fail.

- test_tabline: The tabline in test 'deduplicates named labels' changes when the cwd is not 'mini.nvim'. Solution: increase child.o.columns

- test_snippets: The screenshot in 'Session persists after :edit' assumes that the name of the repro is mini.nvim. Solution: use a dummy statusline.


