### PR TITLE
fix(operators): remove new default `grx` LSP mapping

### DIFF
--- a/lua/mini/operators.lua
+++ b/lua/mini/operators.lua
@@ -729,6 +729,7 @@ H.apply_config = function(config)
       remove_lsp_mapping('n', 'grn')
       remove_lsp_mapping('n', 'grr')
       remove_lsp_mapping('n', 'grt')
+      remove_lsp_mapping('n', 'grx')
     end
 
     if prefix == 'gx' and vim.fn.has('nvim-0.10') == 1 then

--- a/tests/test_operators.lua
+++ b/tests/test_operators.lua
@@ -135,6 +135,7 @@ T['setup()']['removes built-in LSP mappings'] = function()
   eq(child.fn.maparg('gri'), '')
   eq(child.fn.maparg('grn'), '')
   eq(child.fn.maparg('grt'), '')
+  eq(child.fn.maparg('grx'), '')
 end
 
 T['setup()']['remaps built-in `gx` mappings'] = function()


### PR DESCRIPTION
Details

- New builtin lsp mapping "grx" executes `vim.lsp.codelens.run()`

  See PR 37689 in neovim/neovim

  This causes test 'Replace works with `cmdheight=0`' to fail:

  Can not use `child.get_screenshot` because child process is blocked.

  In mini.operators, default `gr*` LSP mappings are removed

- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
