### PR TITLE
fix(pick): Handle history editing with keycodes

### DIFF
--- a/lua/mini/extra.lua
+++ b/lua/mini/extra.lua
@@ -981,7 +981,7 @@ MiniExtra.pickers.history = function(local_opts, opts)
     local cur_match = MiniPick.get_picker_matches().current
     local cur_scope, cur_item = cur_match:match('^(.) (.*)$')
     if not (cur_scope == ':' or cur_scope == '/' or cur_scope == '?') then return end
-    vim.schedule(function() vim.api.nvim_input(cur_scope .. cur_item) end)
+    vim.schedule(function() vim.api.nvim_input(cur_scope .. cur_item:gsub('<', '<lt>')) end)
     return true
   end
   local mappings = { edit_command = { char = '<C-e>', func = edit_command } }

--- a/tests/test_extra.lua
+++ b/tests/test_extra.lua
@@ -2339,6 +2339,7 @@ T['pickers']['history()'] = new_set({
       child.lua('_G.n = 0')
       type_keys(':lua _G.n = _G.n + 1<CR>')
       type_keys(':lua _G.n = _G.n + 2<CR>')
+      type_keys(':echo "<CR>"')
 
       -- Search history
       child.api.nvim_buf_set_lines(0, 0, -1, false, { 'aaa', 'bbb' })
@@ -2509,6 +2510,10 @@ T['pickers']['history()']['has custom "edit_command" mapping'] = function()
   pick_history()
   type_keys('@', '<C-e>')
   validate('', '', true)
+
+  pick_history({ scope = ':' })
+  type_keys('<C-e>')
+  validate(':', 'echo "<CR>"', false)
 
   pick_history({ scope = ':' })
   type_keys('<C-e>')


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
