### PR TITLE
feat(git): add `command.cmd` option to configure `:Git` command name

### DIFF
--- a/doc/mini-git.txt
+++ b/doc/mini-git.txt
@@ -134,8 +134,8 @@ This workflow can be made more interactive when used with mapping, like this: >l
 <
 ------------------------------------------------------------------------------
                                                                           *:Git*
-The `:Git` user command runs `git` CLI call with extra integration for currently
-opened Neovim process:
+The `:Git` user command (renameable via `command.cmd` in |MiniGit.config|) runs
+`git` CLI call with extra integration for currently opened Neovim process:
 - Command is executed inside repository root of the currently active file
   (or |current-directory| if file is not tracked by this module).
 
@@ -242,6 +242,9 @@ Defaults ~
     command = {
       -- Default split direction
       split = 'auto',
+
+      -- Name of the user command (set to another string to avoid conflicts)
+      cmd = 'Git',
     },
   }
 <
@@ -262,6 +265,12 @@ Default: 30000.
 one of "horizontal", "vertical", "tab", or "auto". Value "auto" uses |:vertical|
 if only 'mini.git' buffers are shown in the tabpage and |:tab| otherwise.
 Default: "auto".
+
+`command.cmd` defines the name of the user command created by the module. This
+can be changed to avoid conflicts with other plugins (e.g. 'vim-fugitive') that
+also define a |:Git| command. For example, setting it to "MiniGit" will create
+a `:MiniGit` command instead of `:Git`.
+Default: "Git".
 
 ------------------------------------------------------------------------------
                                                       *MiniGit.show_at_cursor()*

--- a/lua/mini/git.lua
+++ b/lua/mini/git.lua
@@ -300,6 +300,9 @@ MiniGit.config = {
   command = {
     -- Default split direction
     split = 'auto',
+
+    -- Name of the user command (set to another string to avoid conflicts)
+    cmd = 'Git',
   },
 }
 --minidoc_afterlines_end
@@ -645,6 +648,7 @@ H.setup_config = function(config)
 
   H.check_type('job.git_executable', config.job.git_executable, 'string')
   H.check_type('job.timeout', config.job.timeout, 'number')
+  H.check_type('command.cmd', config.command.cmd, 'string')
   if not pcall(H.normalize_split_opt, config.command.split) then
     H.error('`command.split` should be one of "auto", "horizontal", "vertical", "tab"')
   end
@@ -670,7 +674,7 @@ H.is_disabled = function(buf_id) return vim.g.minigit_disable == true or vim.b[b
 
 H.create_user_commands = function()
   local opts = { bang = true, nargs = '+', complete = H.command_complete, desc = 'Execute Git command' }
-  vim.api.nvim_create_user_command('Git', H.command_impl, opts)
+  vim.api.nvim_create_user_command(MiniGit.config.command.cmd, H.command_impl, opts)
 end
 
 -- Autocommands ---------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `command.cmd` config option to allow renaming the `:Git` user command
- Useful for avoiding conflicts with other plugins that define `:Git` (e.g. vim-fugitive)
- Defaults to `"Git"` for backwards compatibility
- Updated help docs to document the new option

Example usage:
```lua
require('mini.git').setup({
  command = { cmd = 'MiniGit' },
})
```

Resolve #1187