### PR TITLE
fix(misc): update `safely` to handle breaking Nightly autocmd changes

### DIFF
--- a/lua/mini/misc.lua
+++ b/lua/mini/misc.lua
@@ -394,6 +394,8 @@ H.execute_later = function()
 end
 
 H.make_defer_autocmd = function(event, pattern, f, trace)
+  pattern = pattern and #pattern > 0 and pattern or nil
+
   local au_id
   local function cb()
     -- Execute exactly once, not once per event or pattern match


### PR DESCRIPTION

- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- PR [38851](https://github.com/neovim/neovim/pull/38851) in neovim/neovim

The test that failed: 'works with "event" without patterns'