### PR TITLE
test(deps): react to Nightly having moved `stdpath("log")`

### DIFF
--- a/tests/test_deps.lua
+++ b/tests/test_deps.lua
@@ -269,7 +269,7 @@ T['setup()']['creates `config` field'] = function()
 
   expect_config('path.package', child.fn.stdpath('data') .. '/site')
   expect_config('path.snapshot', child.fn.stdpath('config') .. '/mini-deps-snap')
-  expect_config('path.log', child.fn.stdpath('state') .. '/mini-deps.log')
+  expect_config('path.log', child.fn.stdpath('log') .. '/mini-deps.log')
 
   expect_config('silent', false)
 end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- See PR [38501](https://github.com/neovim/neovim/pull/38501) in neovim/neovim
