### PR TITLE
test(extra): fix test failing conditionally on mini's local path

### DIFF
--- a/tests/test_extra.lua
+++ b/tests/test_extra.lua
@@ -176,12 +176,6 @@ local get_spawn_log = function() return child.lua_get('_G.spawn_log') end
 
 local clear_spawn_log = function() child.lua('_G.spawn_log = {}') end
 
-local validate_spawn_log = function(ref, index)
-  local present = get_spawn_log()
-  if type(index) == 'number' then present = present[index] end
-  eq(present, ref)
-end
-
 local get_process_log = function() return child.lua_get('_G.process_log') end
 
 local clear_process_log = function() child.lua('_G.process_log = {}') end
@@ -3536,12 +3530,14 @@ end
 
 T['pickers']['oldfiles()']['respects `local_opts.preserve_order`'] = function()
   child.lua('vim.fn.filereadable = function() return 1 end')
-  child.v.oldfiles = { 'axay', 'b', 'aaxy', 'ccc', 'xaa' }
+  local p = function(x) return full_path(make_testpath(x)) end
+
+  child.v.oldfiles = { p('auav'), p('b'), p('aauv'), p('ccc'), p('uaa') }
   pick_oldfiles({ preserve_order = true })
 
-  type_keys('x')
+  type_keys('u')
   eq(get_picker_matches().all_inds, { 1, 3, 5 })
-  type_keys('y')
+  type_keys('v')
   eq(get_picker_matches().all_inds, { 1, 3 })
 end
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- When mini.nvim is checked out locally to for example '~/projects/fix_mini', test 'oldfiles-respect local_opts.preserve_order' fails because search key 'x' is now present in all items

- Function `validate_spawn_log` is unused and has been removed

___

This PR adds the full test path to the test buffers, in order to display only the relative part in the oldfiles picker.

For example, the display of the first item changes from `~/projects/plugins/mini_test_fix_extra/a...` into `tests/dir-extra/auav`.

The search keys have been changed from 'xy' into 'uv'(letters not in `tests/dir-extra`)


I tested a checkout of mini to directory `abcdefghijklmnopqrstuvwxyz0123456789` to make sure that there are no other similar failing tests....


