### PR TITLE
fix(indentscope): skip drawing indicator on closed fold lines

### DIFF
--- a/lua/mini/indentscope.lua
+++ b/lua/mini/indentscope.lua
@@ -987,6 +987,9 @@ H.make_draw_function = function(indicator, opts)
     -- Don't put extmark outside of indicator range
     if not (indicator.top <= l and l <= indicator.bottom) then return true end
 
+    -- Don't draw on lines inside a closed fold (would overlay foldtext)
+    if vim.fn.foldclosed(l) ~= -1 then return true end
+
     return pcall(vim.api.nvim_buf_set_extmark, indicator.buf_id, H.ns_id, l - 1, 0, extmark_opts)
   end
 end


### PR DESCRIPTION
## Problem

 When a fold is closed, the indentscope indicator extmark (placed with `virt_text_pos='overlay'`) overlays on top of the foldtext, making the  fold summary unreadable.

## Reproduction

1. Open a file with folds (e.g. a Lua file with treesitter foldexpr)
2. Use a custom `foldtext` that returns virtual text
3. Close a fold (`zc`) that is inside an indentscope
4. The indentscope `│` character overlays on top of the foldtext, covering characters at that column position

## Fix

One-line guard in `H.make_draw_function` that skips lines belonging
to a closed fold before placing the extmark:

```lua
if vim.fn.foldclosed(l) ~= -1 then return true end

Lines hidden inside a fold don't need extmarks, and the first line
of a fold displays foldtext which should not be overwritten.
```


- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)
