### PR TITLE
fix(sessions): fix error in `restart` when name contains space

### DIFF
--- a/lua/mini/sessions.lua
+++ b/lua/mini/sessions.lua
@@ -359,7 +359,7 @@ MiniSessions.restart = function()
 
   -- Restart Neovim and execute Lua commands to restore necessary session
   local after = {
-    'vim.cmd("source ' .. session_arg .. '")',
+    'vim.cmd("source ' .. session_arg:gsub('\\', '\\\\') .. '")',
     -- Restore 'termguicolors' manually since it is not (yet) autodetected
     'vim.o.termguicolors = ' .. tostring(vim.o.termguicolors),
     'vim.notify("(mini.sessions) Restarted")',

--- a/tests/test_sessions.lua
+++ b/tests/test_sessions.lua
@@ -1065,6 +1065,17 @@ T['restart()']['works without loading the module'] = function()
   validate('')
 end
 
+T['restart()']['works when characters in session name have special meaning'] = function()
+  local validate = setup_cur_session()
+  child.fn.mkdir(empty_dir_path)
+  local session_path = vim.fn.fnameescape(make_path(empty_dir_path, 'new %! session'))
+  child.cmd('mksession! ' .. session_path)
+  local ref_this_session = child.v.this_session
+
+  restart()
+  validate(ref_this_session)
+end
+
 T['restart()']['handles the error during restart'] = function()
   -- No active session
   child.cmd('edit aaa')


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/
CODE_OF_CONDUCT.md)

Details:
- When the name contains a space, an E5107 occurs indicating an invalid escape sequence. 

Resolve #2369

