### PR TITLE
feat(completion): support lsp completion item.command

### DIFF
--- a/lua/mini/completion.lua
+++ b/lua/mini/completion.lua
@@ -1342,7 +1342,7 @@ H.make_lsp_extra_actions = function(lsp_data)
   -- Prefer resolved item over the one from 'textDocument/completion'
   local item = H.completion.lsp.resolved[lsp_data.item_id] or lsp_data.item
 
-  if item.additionalTextEdits == nil and not lsp_data.needs_snippet_insert then return end
+  if item.additionalTextEdits == nil and not lsp_data.needs_snippet_insert and item.command == nil then return end
   local snippet = lsp_data.needs_snippet_insert and H.get_completion_word(item) or nil
 
   -- Make extra actions not only after an explicit `<C-y>` (accept completed
@@ -1370,7 +1370,11 @@ H.make_lsp_extra_actions = function(lsp_data)
     end
 
     -- Try to only apply additional text edits for non-snippet items
-    if snippet == nil then return H.apply_text_edits(item.client_id, item.additionalTextEdits) end
+    if snippet == nil then
+      H.apply_text_edits(item.client_id, item.additionalTextEdits)
+      H.exec_command(item.client_id, item.command)
+      return
+    end
 
     -- Revert to initial completion state to respect text edit coordinates
     local init_base = H.completion.init_base
@@ -1414,6 +1418,13 @@ H.apply_text_edits = function(client_id, text_edits)
   if text_edits == nil then return end
   local offset_encoding = client_id == nil and 'utf-16' or vim.lsp.get_client_by_id(client_id).offset_encoding
   vim.lsp.util.apply_text_edits(text_edits, vim.api.nvim_get_current_buf(), offset_encoding)
+end
+
+H.exec_command = function(client_id, command)
+  if command == nil then return end
+  local client = client_id ~= nil and vim.lsp.get_client_by_id(client_id)
+  if client == nil then return end
+  client:exec_cmd(command)
 end
 
 H.apply_tracked_text_edits = function(client_id, text_edits, from, to)

--- a/tests/test_completion.lua
+++ b/tests/test_completion.lua
@@ -1078,6 +1078,28 @@ T['Manual completion']['applies `additionalTextEdits` from "completionItem/resol
   eq(get_lines(), { 'January' })
 end
 
+T['Manual completion']['executes `command` from completion item'] = function()
+  local command = { title = 'Add import', command = 'add_import', arguments = { 'months' } }
+
+  mock_lsp_items({ { label = 'Hello', command = command } })
+
+  child.lua([[
+    _G.exec_cmd_log = {}
+    local client = vim.lsp.get_client_by_id(_G.months_lsp_client_id)
+    local orig = client.exec_cmd
+    client.exec_cmd = function(self, cmd, ...)
+      table.insert(_G.exec_cmd_log, vim.deepcopy(cmd))
+      return orig(self, cmd, ...)
+    end
+  ]])
+
+  set_lines({})
+  type_keys('i', '<C-Space>', '<C-n>', '<C-y>')
+  eq(get_lines(), { 'Hello' })
+  eq(child.lua_get('#_G.exec_cmd_log'), 1)
+  eq(child.lua_get('_G.exec_cmd_log[1].command'), 'add_import')
+end
+
 T['Manual completion']['prefers completion range from LSP response'] = function()
   set_lines({})
   type_keys('i', 'months.')


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)


Use `client:exec_cmd` to run `command` field attached to completion items, useful for additional command running, found this is not supported while https://github.com/obsidian-nvim/obsidian.nvim/pull/757 and which use command to create new notes on item accept, I think many LSP servers also use it to add auto imports

Did not find any discussions on it and not sure whether it is in scope, feels pretty natural to add. 