### PR TITLE
test(cmdline): react to Nightly adding option 'winpinned'

### DIFF
--- a/tests/test_cmdline.lua
+++ b/tests/test_cmdline.lua
@@ -736,8 +736,8 @@ T['Autocorrect']['works for options'] = function()
   validate_option('setlocal expndtb', 'setlocal expandtab')
 
   -- Should work multiple times
-  type_every_key(':set ET inorecase nowrp invmgic ')
-  validate_cmdline('set et ignorecase nowrap invmagic ')
+  type_every_key(':set ET inorecase nowrtebakp invmgic ')
+  validate_cmdline('set et ignorecase nowritebackup invmagic ')
   type_keys('<Esc>')
 
   -- Correction when option is followed by not space


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- Test 'Autocorrect | works for options' expects 'nowrp' to be corrected into 'nowrap' instead of the new 'nowp'. The test now uses another option to assert the expected behavior

- See [PR 39157](https://github.com/neovim/neovim/pull/39157) in neovim/neovim

