### PR TITLE
test(colors): add more sleeping time to ':Colorscheme' test

### DIFF
--- a/tests/test_colors.lua
+++ b/tests/test_colors.lua
@@ -2233,7 +2233,7 @@ T[':Colorscheme']['accepts several arguments'] = function()
   sleep(default_show_duration - 2 * small_transition_time)
   expect.match(child.cmd_capture('hi Normal'), 'guifg=#5f87af')
 
-  sleep(default_transition_duration + 3 * small_time)
+  sleep(default_transition_duration + small_time + 2 * small_transition_time)
   local blue_normal_fg = '#ffd700'
   expect.match(child.cmd_capture('hi Normal'), 'guifg=' .. blue_normal_fg)
 end


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/nvim-mini/mini.nvim/blob/main/CONTRIBUTING.md)
- [x] I have read [CODE_OF_CONDUCT.md](https://github.com/nvim-mini/mini.nvim/blob/main/CODE_OF_CONDUCT.md)

Details:
- Test ':Colorscheme'-'accepts several arguments' fails regularly, especially when repeating 'make test_colors' multiple times. The solution is to also use small_transition_time in the third step to compensate for time spent in the previous steps.

The total sleeping time in the test was exactly 3000 ms. With this PR, the time is 3020 ms.

